### PR TITLE
outerclothing and suit storage keybinds

### DIFF
--- a/Content.Client/Input/ContentContexts.cs
+++ b/Content.Client/Input/ContentContexts.cs
@@ -71,8 +71,10 @@ namespace Content.Client.Input
             human.AddFunction(ContentKeyFunctions.OpenInventoryMenu);
             human.AddFunction(ContentKeyFunctions.SmartEquipBackpack);
             human.AddFunction(ContentKeyFunctions.SmartEquipBelt);
+            human.AddFunction(ContentKeyFunctions.SmartEquipSuitStorage);
             human.AddFunction(ContentKeyFunctions.OpenBackpack);
             human.AddFunction(ContentKeyFunctions.OpenBelt);
+            human.AddFunction(ContentKeyFunctions.OpenOuterClothing);
             human.AddFunction(ContentKeyFunctions.MouseMiddle);
             human.AddFunction(ContentKeyFunctions.ArcadeUp);
             human.AddFunction(ContentKeyFunctions.ArcadeDown);

--- a/Content.Client/Options/UI/Tabs/KeyRebindTab.xaml.cs
+++ b/Content.Client/Options/UI/Tabs/KeyRebindTab.xaml.cs
@@ -188,8 +188,10 @@ namespace Content.Client.Options.UI.Tabs
             AddHeader("ui-options-header-interaction-adv");
             AddButton(ContentKeyFunctions.SmartEquipBackpack);
             AddButton(ContentKeyFunctions.SmartEquipBelt);
+            AddButton(ContentKeyFunctions.SmartEquipSuitStorage);
             AddButton(ContentKeyFunctions.OpenBackpack);
             AddButton(ContentKeyFunctions.OpenBelt);
+            AddButton(ContentKeyFunctions.OpenOuterClothing);
             AddButton(ContentKeyFunctions.ThrowItemInHand);
             AddButton(ContentKeyFunctions.TryPullObject);
             AddButton(ContentKeyFunctions.MovePulledObject);

--- a/Content.Shared/Input/ContentKeyFunctions.cs
+++ b/Content.Shared/Input/ContentKeyFunctions.cs
@@ -31,8 +31,10 @@ namespace Content.Shared.Input
         public static readonly BoundKeyFunction OpenInventoryMenu = "OpenInventoryMenu";
         public static readonly BoundKeyFunction SmartEquipBackpack = "SmartEquipBackpack";
         public static readonly BoundKeyFunction SmartEquipBelt = "SmartEquipBelt";
+        public static readonly BoundKeyFunction SmartEquipSuitStorage = "SmartEquipSuitStorage";
         public static readonly BoundKeyFunction OpenBackpack = "OpenBackpack";
         public static readonly BoundKeyFunction OpenBelt = "OpenBelt";
+        public static readonly BoundKeyFunction OpenOuterClothing = "OpenOuterClothing";
         public static readonly BoundKeyFunction OpenAHelp = "OpenAHelp";
         public static readonly BoundKeyFunction SwapHands = "SwapHands";
         public static readonly BoundKeyFunction MoveStoredItem = "MoveStoredItem";

--- a/Content.Shared/Interaction/Components/SmartEquipItemSlotComponent.cs
+++ b/Content.Shared/Interaction/Components/SmartEquipItemSlotComponent.cs
@@ -1,0 +1,9 @@
+namespace Content.Shared.Interaction.Components;
+
+/// <summary>
+/// Allow SmartEquip to take the item from this inventory
+/// </summary>
+[RegisterComponent]
+public sealed partial class SmartEquipItemSlotComponent : Component
+{
+}

--- a/Content.Shared/Interaction/SmartEquipSystem.cs
+++ b/Content.Shared/Interaction/SmartEquipSystem.cs
@@ -165,13 +165,10 @@ public sealed class SmartEquipSystem : EntitySystem
         }
 
         // case 3 (itemslot item):
-        if (TryComp<ItemSlotsComponent>(slotItem, out var slots))
+        if (TryComp<ItemSlotsComponent>(slotItem, out var slots) && HasComp<SmartEquipItemSlotComponent>(slotItem))
         {
             if (handItem == null)
             {
-                if (!HasComp<SmartEquipItemSlotComponent>(slotItem))
-                    return;
-
                 ItemSlot? toEjectFrom = null;
 
                 foreach (var slot in slots.Slots.Values)

--- a/Content.Shared/Interaction/SmartEquipSystem.cs
+++ b/Content.Shared/Interaction/SmartEquipSystem.cs
@@ -3,6 +3,7 @@ using Content.Shared.Containers.ItemSlots;
 using Content.Shared.Hands.Components;
 using Content.Shared.Hands.EntitySystems;
 using Content.Shared.Input;
+using Content.Shared.Interaction.Components;
 using Content.Shared.Inventory;
 using Content.Shared.Popups;
 using Content.Shared.Storage;
@@ -168,6 +169,9 @@ public sealed class SmartEquipSystem : EntitySystem
         {
             if (handItem == null)
             {
+                if (!HasComp<SmartEquipItemSlotComponent>(slotItem))
+                    return;
+
                 ItemSlot? toEjectFrom = null;
 
                 foreach (var slot in slots.Slots.Values)

--- a/Content.Shared/Interaction/SmartEquipSystem.cs
+++ b/Content.Shared/Interaction/SmartEquipSystem.cs
@@ -34,6 +34,7 @@ public sealed class SmartEquipSystem : EntitySystem
         CommandBinds.Builder
             .Bind(ContentKeyFunctions.SmartEquipBackpack, InputCmdHandler.FromDelegate(HandleSmartEquipBackpack, handle: false, outsidePrediction: false))
             .Bind(ContentKeyFunctions.SmartEquipBelt, InputCmdHandler.FromDelegate(HandleSmartEquipBelt, handle: false, outsidePrediction: false))
+            .Bind(ContentKeyFunctions.SmartEquipSuitStorage, InputCmdHandler.FromDelegate(HandleSmartEquipSuitStorage, handle: false, outsidePrediction: false))
             .Register<SmartEquipSystem>();
     }
 
@@ -52,6 +53,11 @@ public sealed class SmartEquipSystem : EntitySystem
     private void HandleSmartEquipBelt(ICommonSession? session)
     {
         HandleSmartEquip(session, "belt");
+    }
+
+    private void HandleSmartEquipSuitStorage(ICommonSession? session)
+    {
+        HandleSmartEquip(session, "suitstorage");
     }
 
     private void HandleSmartEquip(ICommonSession? session, string equipmentSlot)

--- a/Content.Shared/Storage/EntitySystems/SharedStorageSystem.cs
+++ b/Content.Shared/Storage/EntitySystems/SharedStorageSystem.cs
@@ -133,6 +133,7 @@ public abstract class SharedStorageSystem : EntitySystem
         CommandBinds.Builder
             .Bind(ContentKeyFunctions.OpenBackpack, InputCmdHandler.FromDelegate(HandleOpenBackpack, handle: false))
             .Bind(ContentKeyFunctions.OpenBelt, InputCmdHandler.FromDelegate(HandleOpenBelt, handle: false))
+            .Bind(ContentKeyFunctions.OpenOuterClothing, InputCmdHandler.FromDelegate(HandleOpenOuterClothing, handle: false))
             .Register<SharedStorageSystem>();
 
         UpdatePrototypeCache();
@@ -1447,6 +1448,11 @@ public abstract class SharedStorageSystem : EntitySystem
     private void HandleOpenBelt(ICommonSession? session)
     {
         HandleToggleSlotUI(session, "belt");
+    }
+
+    private void HandleOpenOuterClothing(ICommonSession? session)
+    {
+        HandleToggleSlotUI(session, "outerClothing");
     }
 
     private void HandleToggleSlotUI(ICommonSession? session, string slot)

--- a/Resources/Changelog/Mira.yml
+++ b/Resources/Changelog/Mira.yml
@@ -301,3 +301,17 @@ Entries:
     type: Tweak
   id: 47
   time: '2024-07-31T16:37:00.0000000+00:00'
+- author: Cojoke-dot
+  changes:
+  - message: Smart-Equip now takes the gun or light out of the slot rather than the items inventory.
+    type: Tweak
+  id: 48
+  time: '2024-08-02T01:37:00.0000000+00:00'
+- author: Doctor-Cpu
+  changes:
+  - message: Added keybind to smart equip the suit storage
+    type: Add
+  - message: Added keybind to open the storage of the outerclothing
+    type: Add
+  id: 49
+  time: '2024-08-02T01:37:00.0000000+00:00'

--- a/Resources/Locale/en-US/escape-menu/ui/options-menu.ftl
+++ b/Resources/Locale/en-US/escape-menu/ui/options-menu.ftl
@@ -149,8 +149,10 @@ ui-options-static-storage-ui = Lock storage window to hotbar
 
 ui-options-function-smart-equip-backpack = Smart-equip to backpack
 ui-options-function-smart-equip-belt = Smart-equip to belt
+ui-options-function-smart-equip-suit-storage = Smart-equip to suit storage
 ui-options-function-open-backpack = Open backpack
 ui-options-function-open-belt = Open belt
+ui-options-function-open-outer-clothing = Open outer clothing
 ui-options-function-throw-item-in-hand = Throw item
 ui-options-function-try-pull-object = Pull object
 ui-options-function-move-pulled-object = Move pulled object

--- a/Resources/Prototypes/Entities/Clothing/Belt/belts.yml
+++ b/Resources/Prototypes/Entities/Clothing/Belt/belts.yml
@@ -537,6 +537,7 @@
           tags:
           - CaptainSabre
   - type: Appearance
+  - type: SmartEquipItemSlot
 
 # Belts without visualizers
 

--- a/Resources/Prototypes/Entities/Objects/Power/portable_recharger.yml
+++ b/Resources/Prototypes/Entities/Objects/Power/portable_recharger.yml
@@ -36,3 +36,4 @@
           components:
           - HitscanBatteryAmmoProvider
           - ProjectileBatteryAmmoProvider
+  - type: SmartEquipItemSlot

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Basic/base_wieldable.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Basic/base_wieldable.yml
@@ -10,4 +10,4 @@
     maxAngle: -30
   - type: Gun
     minAngle: 21
-    maxAngle: 32   
+    maxAngle: 32

--- a/Resources/keybinds.yml
+++ b/Resources/keybinds.yml
@@ -1,4 +1,4 @@
-﻿version: 1 # Not used right now, whatever.
+version: 1 # Not used right now, whatever.
 binds:
 - function: UIClick
   type: State
@@ -251,6 +251,10 @@ binds:
   type: State
   key: E
   mod1: Shift
+- function: SmartEquipSuitStorage
+  type: State
+  key: C
+  mod1: Shift
 - function: OpenBackpack
   type: State
   key: V
@@ -258,6 +262,10 @@ binds:
   type: State
   key: V
   mod1: Shift
+- function: OpenOuterClothing
+  type: State
+  key: C
+  mod1: Alt
 - function: ShowDebugConsole
   type: State
   key: Tilde


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->
## About the PR
<!-- What did you change in this PR? -->
2 new keybinds:
- Smart equip suit storage
- Open storage of outerclothing

## Why / Balance
<!-- Why was it changed? Link any discussions or issues here. Please discuss how this would affect game balance. -->
Keyboard shortuts good.

## Media
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->

https://github.com/user-attachments/assets/3cc6aeec-c00e-4d80-a07f-e59da1d0ec22

- [X] I have added screenshots/videos to this PR showcasing its changes ingame, **or** this PR does not require an ingame showcase
