### PR TITLE
Misc reverts and a bugfix

### DIFF
--- a/Resources/Changelog/Mira.yml
+++ b/Resources/Changelog/Mira.yml
@@ -417,3 +417,15 @@ Entries:
     type: Add
   id: 64
   time: '2024-09-10T16:54:00.0000000+00:00'
+- author: Thurtik
+  changes:
+  - message: Combat boots now share all benefits with jackboots and have been added to loadouts as a cosmetic option
+    type: Add
+  - message: Solid plasma crates ordered at cargo now contain 3 stacks again
+    type: Tweak
+  - message: RD closets now contain a binary translator encryption key again
+    type: Add
+  - message: Fixed inhand sprite toggling for telescopic shields and batons
+    type: Fix
+  id: 65
+  time: '2024-09-11T22:24:00.0000000+00:00'

--- a/Resources/Prototypes/Catalog/Fills/Crates/materials.yml
+++ b/Resources/Prototypes/Catalog/Fills/Crates/materials.yml
@@ -79,11 +79,12 @@
   id: CrateMaterialPlasma
   parent: CratePlasma
   name: solid plasma crate
-  description: 30 sheets of plasma.
+  description: 90 sheets of plasma.
   components:
   - type: StorageFill
     contents:
       - id: SheetPlasma
+        amount: 3
 
 - type: entity
   id: CrateMaterialCardboard

--- a/Resources/Prototypes/Catalog/Fills/Lockers/heads.yml
+++ b/Resources/Prototypes/Catalog/Fills/Lockers/heads.yml
@@ -267,6 +267,7 @@
     - id: ProtolatheMachineCircuitboard
     - id: ResearchComputerCircuitboard
     - id: RubberStampRd
+    - id: EncryptionKeyBinary
 
 # Hardsuit table, used for suit storage as well
 - type: entityTable

--- a/Resources/Prototypes/Entities/Clothing/Shoes/boots.yml
+++ b/Resources/Prototypes/Entities/Clothing/Shoes/boots.yml
@@ -56,6 +56,8 @@
     sprite: Clothing/Shoes/Boots/combatboots.rsi
   - type: Clothing
     sprite: Clothing/Shoes/Boots/combatboots.rsi
+  - type: ClothingSlowOnDamageModifier
+    modifier: 0.5
 
 - type: entity
   parent: ClothingShoesMilitaryBase

--- a/Resources/Prototypes/Entities/Objects/Shields/shields.yml
+++ b/Resources/Prototypes/Entities/Objects/Shields/shields.yml
@@ -502,6 +502,7 @@
         malus: 0.6
     - type: ItemToggleSize
       activatedSize: Huge
+    - type: ItemTogglePointLight
     - type: Sprite
       sprite: Objects/Weapons/Melee/teleriot_shield.rsi
       layers:
@@ -515,6 +516,12 @@
       heldPrefix: teleriot
     - type: UseDelay
       delay: 0.5
+    - type: PointLight
+      enabled: false
+      radius: 0
+      energy: 0
+      color: white
+      netsync: false
     - type: ToggleableLightVisuals
       spriteLayer: shield
       inhandVisuals:

--- a/Resources/Prototypes/Entities/Objects/Weapons/security.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/security.yml
@@ -133,7 +133,14 @@
   - type: StaminaDamageOnHit
     damage: 25
     sound: /Audio/Weapons/egloves.ogg
+  - type: ItemTogglePointLight
   - type: UseDelay
+  - type: PointLight
+    enabled: false
+    radius: 0
+    energy: 0
+    color: white
+    netsync: false
   - type: Appearance
   - type: GenericVisualizer
     visuals:

--- a/Resources/Prototypes/Loadouts/loadout_groups.yml
+++ b/Resources/Prototypes/Loadouts/loadout_groups.yml
@@ -1027,6 +1027,7 @@
   id: SecurityShoes
   name: loadout-group-security-shoes
   loadouts:
+  - CombatBoots
   - JackBoots
   - SecurityWinterBoots
 


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
- Added the slowness resist buff to combat boots (so now they and jackboots are the same utility-wise)
- Added combat boots to loadouts
- Made solid plasma crates contain 90 solid plasma again (upstream nerfed it to 30 per)
- RD closets now have a binary key in them again
- Fixed telebaton and teleshield sprite toggling not working (upstream changed how the system works)

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->

## Technical details
<!-- Summary of code changes for easier review. -->

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [ ] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [ ] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
:cl:
- add: Combat boots now share all benefits with jackboots and have been added to loadouts as a cosmetic option
- tweak: Solid plasma crates ordered at cargo now contain 3 stacks again
- add: RD closets now contain a binary translator encryption key again
- fix: Fixed inhand sprite toggling for telescopic shields and batons
