### PR TITLE
improper brigmed access on cluster

### DIFF
--- a/Resources/Maps/cluster.yml
+++ b/Resources/Maps/cluster.yml
@@ -6544,7 +6544,7 @@ entities:
       pos: -3.5,20.5
       parent: 1
     - type: Door
-      secondsUntilStateChange: -533.79816
+      secondsUntilStateChange: -581.10864
       state: Opening
     - type: DeviceLinkSource
       lastSignals:
@@ -57318,13 +57318,6 @@ entities:
     - type: Transform
       pos: -11.34931,-33.29647
       parent: 1
-- proto: OverlordCircuitBoard
-  entities:
-  - uid: 9255
-    components:
-    - type: Transform
-      pos: -2.275197,50.598377
-      parent: 1
 - proto: OxygenCanister
   entities:
   - uid: 3356
@@ -80191,6 +80184,20 @@ entities:
     - type: Transform
       pos: 36.5,13.5
       parent: 1
+- proto: WindoorSecureBrigLocked
+  entities:
+  - uid: 1775
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 22.5,7.5
+      parent: 1
+  - uid: 1776
+    components:
+    - type: Transform
+      rot: 3.141592653589793 rad
+      pos: 21.5,7.5
+      parent: 1
 - proto: WindoorSecureCargoLocked
   entities:
   - uid: 7243
@@ -80344,24 +80351,6 @@ entities:
       parent: 1
 - proto: WindoorSecureSecurityLocked
   entities:
-  - uid: 1775
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 21.5,7.5
-      parent: 1
-    - type: AccessReader
-      access:
-      - - Brig
-  - uid: 1776
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 22.5,7.5
-      parent: 1
-    - type: AccessReader
-      access:
-      - - Brig
   - uid: 4900
     components:
     - type: Transform


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
<!-- What did you change? -->
changed the double windoors from security access to brigade access

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->

## Technical details
<!-- Summary of code changes for easier review. -->

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [ ] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [ ] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
