### PR TITLE
Anomaly scanner storable in utility belt

### DIFF
--- a/Resources/Changelog/Mira.yml
+++ b/Resources/Changelog/Mira.yml
@@ -671,3 +671,9 @@ Entries:
     type: Add
   id: 99
   time: '2024-10-15T09:15:00.0000000+00:00'
+- author: Wudanty
+  changes:
+  - message: Added anomaly scanner to utility belt's whitelist'
+    type: Add
+  id: 100
+  time: '2024-10-19T16:00:00.0000000+00:00'

--- a/Resources/Prototypes/Entities/Clothing/Belt/belts.yml
+++ b/Resources/Prototypes/Entities/Clothing/Belt/belts.yml
@@ -43,6 +43,7 @@
         - TrayScanner
         - GasAnalyzer
         - HandLabeler
+        - AnomalyScanner
   - type: ItemMapper
     mapLayers:
       drill:


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Added anomaly scanner to utility belt's whitelist. It just makes sense doesn't it?

## Why / Balance
Scientists don't waste item slots in backpack but in belt now!!

## Technical details
one line of yml

## Media
I believe anyone who reads this has enough imagination.



:cl:
- tweak: Changed utility belt's whitelist to include anomaly scanner.