### PR TITLE
personal ai learns the languages of mankind

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Fun/pai.yml
+++ b/Resources/Prototypes/Entities/Objects/Fun/pai.yml
@@ -76,6 +76,13 @@
   - type: SpeciesLanguage
     spokenLanguages:
     - Binary
+    - Common
+    - Draconic
+    - Moffic
+    - Calcic
+    - Slime
+    - Monkey
+    - Buzzwords
 
 - type: entity
   parent: [ PersonalAI, BaseSyndicateContraband]


### PR DESCRIPTION
## About the PR
personal ai can now talk in every species language

## Why / Balance
i think a phone should have access to the wikipedia by now or a guide on languages! might even help the owners of the phone

## Technical details
added all species language currently available into personal ai's ghost role

## Requirements
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.

## Changelog
personal ai now understands every language in space