### PR TITLE
Roundstart equipment for engi 25/10/2024

### DIFF
--- a/Resources/Prototypes/Roles/Jobs/Engineering/atmospheric_technician.yml
+++ b/Resources/Prototypes/Roles/Jobs/Engineering/atmospheric_technician.yml
@@ -23,6 +23,7 @@
     id: AtmosPDA
     belt: ClothingBeltUtilityEngineering
     ears: ClothingHeadsetEngineering
+    gloves: ClothingHandsGlovesColorYellow
   #storage:
     #back:
     #- Stuff

--- a/Resources/Prototypes/Roles/Jobs/Engineering/atmospheric_technician.yml
+++ b/Resources/Prototypes/Roles/Jobs/Engineering/atmospheric_technician.yml
@@ -24,6 +24,8 @@
     belt: ClothingBeltUtilityEngineering
     ears: ClothingHeadsetEngineering
     gloves: ClothingHandsGlovesColorYellow
+    pocket1: trayScanner
+    pocket2: GasAnalyzer
   #storage:
     #back:
     #- Stuff

--- a/Resources/Prototypes/Roles/Jobs/Engineering/chief_engineer.yml
+++ b/Resources/Prototypes/Roles/Jobs/Engineering/chief_engineer.yml
@@ -44,6 +44,7 @@
     eyes: ClothingEyesGlassesMeson
     ears: ClothingHeadsetCE
     belt: ClothingBeltUtilityEngineering
+    gloves: ClothingHandsGlovesColorYellow
   storage:
     back:
     - Telescopicbaton

--- a/Resources/Prototypes/Roles/Jobs/Engineering/station_engineer.yml
+++ b/Resources/Prototypes/Roles/Jobs/Engineering/station_engineer.yml
@@ -23,6 +23,7 @@
     eyes: ClothingEyesGlassesMeson
     belt: ClothingBeltUtilityEngineering
     ears: ClothingHeadsetEngineering
+    gloves: ClothingHandsGlovesColorYellow
   #storage:
     #back:
     #- Stuff

--- a/Resources/Prototypes/Roles/Jobs/Engineering/station_engineer.yml
+++ b/Resources/Prototypes/Roles/Jobs/Engineering/station_engineer.yml
@@ -24,6 +24,8 @@
     belt: ClothingBeltUtilityEngineering
     ears: ClothingHeadsetEngineering
     gloves: ClothingHandsGlovesColorYellow
+    pocket1: trayScanner
+    pocket2: GasAnalyzer
   #storage:
     #back:
     #- Stuff


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
changed what items engi spawn on themselves at roundstart

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->


**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
- add: tray and gas anilysers now spawn in the pockets of engi and atmos at roundstart
- add: engi, atmos and ce now spawn with insuls equipped
