### PR TITLE
Replaced the swabs in the NutriMax 04/11/2024

### DIFF
--- a/Resources/Changelog/Mira.yml
+++ b/Resources/Changelog/Mira.yml
@@ -763,5 +763,11 @@ Entries:
     type: Fix
     id: 113
     time: '2024-11-03T07:18:08.0000000+00:00'
+- author: aspiffyfellow
+  changes:
+  - message: Replaced swabs in the NutriMax with a box of swabs and added a bin bag to the vendor to put the swabs after your done.
+    type: Tweak
+    id: 114
+    time: '2024-11-04T07:20:25.0000000+00:00'
 
 

--- a/Resources/Prototypes/Catalog/VendingMachines/Inventories/nutri.yml
+++ b/Resources/Prototypes/Catalog/VendingMachines/Inventories/nutri.yml
@@ -15,8 +15,9 @@
     RobustHarvestChemistryBottle: 3
     EZNutrientChemistryBottle: 3
     Bucket: 3
-    DiseaseSwab: 20
+    BoxMouthSwab: 1
     BoxAgrichem: 1
+    TrashBag: 1
     #TO DO:
     #plant analyzer
   emaggedInventory:


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
Replaced the swabs in the NutriMax and added a bin bag to the vendor

## Why / Balance
i feel 20 individual swabs is annoying and impractical so i replaced them with the swab box
the bin bad was added so botanist's can dispose of the used swabs

## Technical details
<!-- Summary of code changes for easier review. -->

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
- tweak: Replaced swabs in the NutriMax with a box of swabs and added a bin bag to the vendor to put the swabs after your done.
