### PR TITLE
Changed evac shuttle to non Christmas version 05/01/2025

### DIFF
--- a/Resources/Maps/Shuttles/emergency_mir.yml
+++ b/Resources/Maps/Shuttles/emergency_mir.yml
@@ -983,18 +983,18 @@ entities:
     - type: DeviceList
       devices:
       - 37
-      - 413
-      - 412
-      - 411
-      - 410
-      - 409
-      - 408
-      - 425
-      - 472
-      - 414
+      - 403
+      - 402
+      - 401
+      - 400
+      - 399
+      - 398
       - 415
-      - 416
-      - 417
+      - 458
+      - 404
+      - 405
+      - 406
+      - 407
   - uid: 16
     components:
     - type: Transform
@@ -1003,13 +1003,13 @@ entities:
       parent: 1
     - type: DeviceList
       devices:
-      - 413
-      - 412
-      - 411
-      - 410
-      - 409
-      - 408
-      - 471
+      - 403
+      - 402
+      - 401
+      - 400
+      - 399
+      - 398
+      - 457
       - 38
   - uid: 17
     components:
@@ -1020,9 +1020,9 @@ entities:
     - type: DeviceList
       devices:
       - 36
-      - 476
-      - 421
-      - 420
+      - 462
+      - 411
+      - 410
   - uid: 18
     components:
     - type: Transform
@@ -1030,9 +1030,9 @@ entities:
       parent: 1
     - type: DeviceList
       devices:
-      - 423
-      - 422
-      - 474
+      - 413
+      - 412
+      - 460
       - 34
   - uid: 19
     components:
@@ -1043,8 +1043,8 @@ entities:
     - type: DeviceList
       devices:
       - 40
-      - 473
-      - 424
+      - 459
+      - 414
   - uid: 20
     components:
     - type: Transform
@@ -1052,8 +1052,8 @@ entities:
       parent: 1
     - type: DeviceList
       devices:
-      - 422
-      - 475
+      - 412
+      - 461
       - 35
   - uid: 21
     components:
@@ -1062,19 +1062,19 @@ entities:
       parent: 1
     - type: DeviceList
       devices:
-      - 414
-      - 415
-      - 416
-      - 417
-      - 477
+      - 404
+      - 405
+      - 406
+      - 407
+      - 463
       - 41
-      - 418
-      - 419
+      - 408
+      - 409
       - 33
-      - 423
-      - 424
-      - 420
-      - 421
+      - 413
+      - 414
+      - 410
+      - 411
   - uid: 22
     components:
     - type: Transform
@@ -1083,9 +1083,9 @@ entities:
       parent: 1
     - type: DeviceList
       devices:
-      - 478
+      - 464
       - 39
-      - 425
+      - 415
 - proto: AirCanister
   entities:
   - uid: 23
@@ -1342,16 +1342,9 @@ entities:
     - type: Transform
       pos: 4.5,9.5
       parent: 1
-- proto: BudgetInsulsDrinkGlass
-  entities:
-  - uid: 58
-    components:
-    - type: Transform
-      pos: -1.645513,-3.7827349
-      parent: 1
 - proto: ButtonFrameCaution
   entities:
-  - uid: 59
+  - uid: 58
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -1359,507 +1352,512 @@ entities:
       parent: 1
 - proto: ButtonFrameCautionSecurity
   entities:
-  - uid: 60
+  - uid: 59
     components:
     - type: Transform
       pos: 0.5,10.5
       parent: 1
 - proto: CableApcExtension
   entities:
-  - uid: 61
+  - uid: 60
     components:
     - type: Transform
       pos: 4.5,14.5
       parent: 1
-  - uid: 62
+  - uid: 61
     components:
     - type: Transform
       pos: 3.5,14.5
       parent: 1
-  - uid: 63
+  - uid: 62
     components:
     - type: Transform
       pos: 2.5,14.5
       parent: 1
-  - uid: 64
+  - uid: 63
     components:
     - type: Transform
       pos: 1.5,14.5
       parent: 1
-  - uid: 65
+  - uid: 64
     components:
     - type: Transform
       pos: 0.5,14.5
       parent: 1
-  - uid: 66
+  - uid: 65
     components:
     - type: Transform
       pos: -0.5,14.5
       parent: 1
-  - uid: 67
+  - uid: 66
     components:
     - type: Transform
       pos: -1.5,14.5
       parent: 1
-  - uid: 68
+  - uid: 67
     components:
     - type: Transform
       pos: -2.5,14.5
       parent: 1
-  - uid: 69
+  - uid: 68
     components:
     - type: Transform
       pos: 0.5,15.5
       parent: 1
-  - uid: 70
+  - uid: 69
     components:
     - type: Transform
       pos: 0.5,16.5
       parent: 1
-  - uid: 71
+  - uid: 70
     components:
     - type: Transform
       pos: -1.5,16.5
       parent: 1
-  - uid: 72
+  - uid: 71
     components:
     - type: Transform
       pos: -0.5,16.5
       parent: 1
-  - uid: 73
+  - uid: 72
     components:
     - type: Transform
       pos: 1.5,16.5
       parent: 1
-  - uid: 74
+  - uid: 73
     components:
     - type: Transform
       pos: 2.5,16.5
       parent: 1
-  - uid: 75
+  - uid: 74
     components:
     - type: Transform
       pos: 0.5,13.5
       parent: 1
-  - uid: 76
+  - uid: 75
     components:
     - type: Transform
       pos: 0.5,12.5
       parent: 1
-  - uid: 77
+  - uid: 76
     components:
     - type: Transform
       pos: 0.5,11.5
       parent: 1
-  - uid: 78
+  - uid: 77
     components:
     - type: Transform
       pos: 3.5,13.5
       parent: 1
-  - uid: 79
+  - uid: 78
     components:
     - type: Transform
       pos: 3.5,12.5
       parent: 1
-  - uid: 80
+  - uid: 79
     components:
     - type: Transform
       pos: 3.5,11.5
       parent: 1
-  - uid: 81
+  - uid: 80
     components:
     - type: Transform
       pos: 3.5,10.5
       parent: 1
-  - uid: 82
+  - uid: 81
     components:
     - type: Transform
       pos: -0.5,11.5
       parent: 1
-  - uid: 83
+  - uid: 82
     components:
     - type: Transform
       pos: -1.5,11.5
       parent: 1
-  - uid: 84
+  - uid: 83
     components:
     - type: Transform
       pos: -2.5,11.5
       parent: 1
-  - uid: 85
+  - uid: 84
     components:
     - type: Transform
       pos: -3.5,11.5
       parent: 1
-  - uid: 86
+  - uid: 85
     components:
     - type: Transform
       pos: -4.5,11.5
       parent: 1
-  - uid: 87
+  - uid: 86
     components:
     - type: Transform
       pos: -4.5,12.5
       parent: 1
-  - uid: 88
+  - uid: 87
     components:
     - type: Transform
       pos: -4.5,13.5
       parent: 1
-  - uid: 89
+  - uid: 88
     components:
     - type: Transform
       pos: 4.5,11.5
       parent: 1
-  - uid: 90
+  - uid: 89
     components:
     - type: Transform
       pos: 5.5,11.5
       parent: 1
-  - uid: 91
+  - uid: 90
     components:
     - type: Transform
       pos: 5.5,12.5
       parent: 1
-  - uid: 92
+  - uid: 91
     components:
     - type: Transform
       pos: 5.5,13.5
       parent: 1
-  - uid: 93
+  - uid: 92
     components:
     - type: Transform
       pos: 1.5,10.5
       parent: 1
-  - uid: 94
+  - uid: 93
     components:
     - type: Transform
       pos: 1.5,9.5
       parent: 1
-  - uid: 95
+  - uid: 94
     components:
     - type: Transform
       pos: 1.5,8.5
       parent: 1
-  - uid: 96
+  - uid: 95
     components:
     - type: Transform
       pos: 0.5,8.5
       parent: 1
-  - uid: 97
+  - uid: 96
     components:
     - type: Transform
       pos: -0.5,8.5
       parent: 1
-  - uid: 98
+  - uid: 97
     components:
     - type: Transform
       pos: 2.5,9.5
       parent: 1
-  - uid: 99
+  - uid: 98
     components:
     - type: Transform
       pos: 1.5,7.5
       parent: 1
-  - uid: 100
+  - uid: 99
     components:
     - type: Transform
       pos: 2.5,7.5
       parent: 1
-  - uid: 101
+  - uid: 100
     components:
     - type: Transform
       pos: 3.5,7.5
       parent: 1
-  - uid: 102
+  - uid: 101
     components:
     - type: Transform
       pos: 4.5,7.5
       parent: 1
-  - uid: 103
+  - uid: 102
     components:
     - type: Transform
       pos: 4.5,8.5
       parent: 1
-  - uid: 104
+  - uid: 103
     components:
     - type: Transform
       pos: 2.5,5.5
       parent: 1
-  - uid: 105
+  - uid: 104
     components:
     - type: Transform
       pos: 2.5,6.5
       parent: 1
-  - uid: 106
+  - uid: 105
     components:
     - type: Transform
       pos: 3.5,5.5
       parent: 1
-  - uid: 107
+  - uid: 106
     components:
     - type: Transform
       pos: 4.5,5.5
       parent: 1
-  - uid: 108
+  - uid: 107
     components:
     - type: Transform
       pos: 5.5,5.5
       parent: 1
-  - uid: 109
+  - uid: 108
     components:
     - type: Transform
       pos: 2.5,4.5
       parent: 1
-  - uid: 110
+  - uid: 109
     components:
     - type: Transform
       pos: 2.5,3.5
       parent: 1
-  - uid: 111
+  - uid: 110
     components:
     - type: Transform
       pos: 2.5,2.5
       parent: 1
-  - uid: 112
+  - uid: 111
     components:
     - type: Transform
       pos: 2.5,1.5
       parent: 1
-  - uid: 113
+  - uid: 112
     components:
     - type: Transform
       pos: 3.5,3.5
       parent: 1
-  - uid: 114
+  - uid: 113
     components:
     - type: Transform
       pos: 4.5,3.5
       parent: 1
-  - uid: 115
+  - uid: 114
     components:
     - type: Transform
       pos: 5.5,3.5
       parent: 1
-  - uid: 116
+  - uid: 115
     components:
     - type: Transform
       pos: 3.5,1.5
       parent: 1
-  - uid: 117
+  - uid: 116
     components:
     - type: Transform
       pos: -1.5,0.5
       parent: 1
-  - uid: 118
+  - uid: 117
     components:
     - type: Transform
       pos: -1.5,1.5
       parent: 1
-  - uid: 119
+  - uid: 118
     components:
     - type: Transform
       pos: -1.5,2.5
       parent: 1
-  - uid: 120
+  - uid: 119
     components:
     - type: Transform
       pos: -1.5,3.5
       parent: 1
-  - uid: 121
+  - uid: 120
     components:
     - type: Transform
       pos: -1.5,4.5
       parent: 1
-  - uid: 122
+  - uid: 121
     components:
     - type: Transform
       pos: -1.5,5.5
       parent: 1
-  - uid: 123
+  - uid: 122
     components:
     - type: Transform
       pos: -0.5,2.5
       parent: 1
-  - uid: 124
+  - uid: 123
     components:
     - type: Transform
       pos: 0.5,2.5
       parent: 1
-  - uid: 125
+  - uid: 124
     components:
     - type: Transform
       pos: -2.5,2.5
       parent: 1
-  - uid: 126
+  - uid: 125
     components:
     - type: Transform
       pos: -3.5,2.5
       parent: 1
-  - uid: 127
+  - uid: 126
     components:
     - type: Transform
       pos: -3.5,3.5
       parent: 1
-  - uid: 128
+  - uid: 127
     components:
     - type: Transform
       pos: -3.5,4.5
       parent: 1
-  - uid: 129
+  - uid: 128
     components:
     - type: Transform
       pos: -3.5,5.5
       parent: 1
-  - uid: 130
+  - uid: 129
     components:
     - type: Transform
       pos: -0.5,-6.5
       parent: 1
-  - uid: 131
+  - uid: 130
     components:
     - type: Transform
       pos: -0.5,-5.5
       parent: 1
-  - uid: 132
+  - uid: 131
     components:
     - type: Transform
       pos: -0.5,-4.5
       parent: 1
-  - uid: 133
+  - uid: 132
     components:
     - type: Transform
       pos: -0.5,-3.5
       parent: 1
-  - uid: 134
+  - uid: 133
     components:
     - type: Transform
       pos: -0.5,-2.5
       parent: 1
-  - uid: 135
+  - uid: 134
     components:
     - type: Transform
       pos: -0.5,-1.5
       parent: 1
-  - uid: 136
+  - uid: 135
     components:
     - type: Transform
       pos: -0.5,-0.5
       parent: 1
-  - uid: 137
+  - uid: 136
     components:
     - type: Transform
       pos: -1.5,-2.5
       parent: 1
-  - uid: 138
+  - uid: 137
     components:
     - type: Transform
       pos: -2.5,-2.5
       parent: 1
-  - uid: 139
+  - uid: 138
     components:
     - type: Transform
       pos: -3.5,-2.5
       parent: 1
-  - uid: 140
+  - uid: 139
     components:
     - type: Transform
       pos: -3.5,-1.5
       parent: 1
-  - uid: 141
+  - uid: 140
     components:
     - type: Transform
       pos: -3.5,-0.5
       parent: 1
-  - uid: 142
+  - uid: 141
     components:
     - type: Transform
       pos: -3.5,-3.5
       parent: 1
-  - uid: 143
+  - uid: 142
     components:
     - type: Transform
       pos: -3.5,-4.5
       parent: 1
-  - uid: 144
+  - uid: 143
     components:
     - type: Transform
       pos: -3.5,-5.5
       parent: 1
-  - uid: 145
+  - uid: 144
     components:
     - type: Transform
       pos: 4.5,-6.5
       parent: 1
-  - uid: 146
+  - uid: 145
     components:
     - type: Transform
       pos: 4.5,-5.5
       parent: 1
-  - uid: 147
+  - uid: 146
     components:
     - type: Transform
       pos: 4.5,-4.5
       parent: 1
-  - uid: 148
+  - uid: 147
     components:
     - type: Transform
       pos: 4.5,-3.5
       parent: 1
-  - uid: 149
+  - uid: 148
     components:
     - type: Transform
       pos: 4.5,-2.5
       parent: 1
-  - uid: 150
+  - uid: 149
     components:
     - type: Transform
       pos: 4.5,-1.5
       parent: 1
-  - uid: 151
+  - uid: 150
     components:
     - type: Transform
       pos: 4.5,-0.5
       parent: 1
-  - uid: 152
+  - uid: 151
     components:
     - type: Transform
       pos: 3.5,-1.5
       parent: 1
-  - uid: 153
+  - uid: 152
     components:
     - type: Transform
       pos: 2.5,-1.5
       parent: 1
-  - uid: 154
+  - uid: 153
     components:
     - type: Transform
       pos: 1.5,-1.5
       parent: 1
-  - uid: 155
+  - uid: 154
     components:
     - type: Transform
       pos: 3.5,-4.5
       parent: 1
-  - uid: 156
+  - uid: 155
     components:
     - type: Transform
       pos: 2.5,-4.5
       parent: 1
-  - uid: 157
+  - uid: 156
     components:
     - type: Transform
       pos: 1.5,-4.5
       parent: 1
-  - uid: 158
+  - uid: 157
     components:
     - type: Transform
       pos: 5.5,-4.5
       parent: 1
-  - uid: 159
+  - uid: 158
     components:
     - type: Transform
       pos: 5.5,-2.5
+      parent: 1
+  - uid: 159
+    components:
+    - type: Transform
+      pos: 2.5,-7.5
       parent: 1
   - uid: 160
     components:
@@ -1869,678 +1867,678 @@ entities:
   - uid: 161
     components:
     - type: Transform
-      pos: 2.5,-7.5
+      pos: 2.5,-8.5
       parent: 1
   - uid: 162
     components:
     - type: Transform
-      pos: 2.5,-8.5
+      pos: 2.5,-6.5
       parent: 1
   - uid: 163
     components:
     - type: Transform
-      pos: 2.5,-6.5
+      pos: 2.5,-9.5
       parent: 1
   - uid: 164
     components:
     - type: Transform
-      pos: 2.5,-9.5
+      pos: 1.5,-9.5
       parent: 1
   - uid: 165
     components:
     - type: Transform
-      pos: 1.5,-9.5
+      pos: 0.5,-9.5
       parent: 1
   - uid: 166
     components:
     - type: Transform
-      pos: 0.5,-9.5
+      pos: -0.5,-9.5
       parent: 1
   - uid: 167
     components:
     - type: Transform
-      pos: -0.5,-9.5
+      pos: -1.5,-9.5
       parent: 1
   - uid: 168
     components:
     - type: Transform
-      pos: -1.5,-9.5
+      pos: -2.5,-9.5
       parent: 1
   - uid: 169
     components:
     - type: Transform
-      pos: -2.5,-9.5
+      pos: -2.5,-10.5
       parent: 1
   - uid: 170
     components:
     - type: Transform
-      pos: -2.5,-10.5
+      pos: -1.5,-8.5
       parent: 1
   - uid: 171
     components:
     - type: Transform
-      pos: -1.5,-8.5
+      pos: -1.5,-7.5
       parent: 1
   - uid: 172
     components:
     - type: Transform
-      pos: -1.5,-7.5
+      pos: 0.5,-10.5
       parent: 1
   - uid: 173
     components:
     - type: Transform
-      pos: 0.5,-10.5
+      pos: 0.5,-11.5
       parent: 1
   - uid: 174
     components:
     - type: Transform
-      pos: 0.5,-11.5
+      pos: 0.5,-12.5
       parent: 1
   - uid: 175
     components:
     - type: Transform
-      pos: 0.5,-12.5
+      pos: 3.5,-9.5
       parent: 1
   - uid: 176
     components:
     - type: Transform
-      pos: 3.5,-9.5
+      pos: 4.5,-9.5
       parent: 1
   - uid: 177
     components:
     - type: Transform
-      pos: 4.5,-9.5
+      pos: 5.5,-9.5
       parent: 1
   - uid: 178
     components:
     - type: Transform
-      pos: 5.5,-9.5
+      pos: 5.5,-8.5
       parent: 1
   - uid: 179
     components:
     - type: Transform
-      pos: 5.5,-8.5
+      pos: 5.5,-7.5
       parent: 1
   - uid: 180
     components:
     - type: Transform
-      pos: 5.5,-7.5
+      pos: -3.5,-9.5
       parent: 1
   - uid: 181
     components:
     - type: Transform
-      pos: -3.5,-9.5
+      pos: -4.5,-9.5
       parent: 1
   - uid: 182
     components:
     - type: Transform
-      pos: -4.5,-9.5
+      pos: -4.5,-8.5
       parent: 1
   - uid: 183
     components:
     - type: Transform
-      pos: -4.5,-8.5
+      pos: -4.5,-7.5
       parent: 1
   - uid: 184
     components:
     - type: Transform
-      pos: -4.5,-7.5
+      pos: -2.5,-11.5
       parent: 1
   - uid: 185
     components:
     - type: Transform
-      pos: -2.5,-11.5
+      pos: -2.5,-12.5
       parent: 1
   - uid: 186
     components:
     - type: Transform
-      pos: -2.5,-12.5
+      pos: -3.5,-11.5
       parent: 1
   - uid: 187
     components:
     - type: Transform
-      pos: -3.5,-11.5
+      pos: 3.5,-10.5
       parent: 1
   - uid: 188
     components:
     - type: Transform
-      pos: 3.5,-10.5
+      pos: 3.5,-11.5
       parent: 1
   - uid: 189
     components:
     - type: Transform
-      pos: 3.5,-11.5
-      parent: 1
-  - uid: 190
-    components:
-    - type: Transform
       pos: 3.5,-12.5
       parent: 1
-  - uid: 191
+  - uid: 190
     components:
     - type: Transform
       pos: 4.5,-11.5
       parent: 1
 - proto: CableHV
   entities:
-  - uid: 192
+  - uid: 191
     components:
     - type: Transform
       pos: -0.5,-12.5
       parent: 1
-  - uid: 193
+  - uid: 192
     components:
     - type: Transform
       pos: 0.5,-12.5
       parent: 1
-  - uid: 194
+  - uid: 193
     components:
     - type: Transform
       pos: 1.5,-12.5
       parent: 1
-  - uid: 195
+  - uid: 194
     components:
     - type: Transform
       pos: -0.5,-11.5
       parent: 1
-  - uid: 196
+  - uid: 195
     components:
     - type: Transform
       pos: -0.5,-10.5
       parent: 1
-  - uid: 197
+  - uid: 196
     components:
     - type: Transform
       pos: 0.5,-10.5
       parent: 1
-  - uid: 198
+  - uid: 197
     components:
     - type: Transform
       pos: 1.5,-10.5
       parent: 1
-  - uid: 199
+  - uid: 198
     components:
     - type: Transform
       pos: 1.5,-9.5
       parent: 1
-  - uid: 200
+  - uid: 199
     components:
     - type: Transform
       pos: 2.5,-9.5
       parent: 1
-  - uid: 201
+  - uid: 200
     components:
     - type: Transform
       pos: 2.5,-8.5
       parent: 1
-  - uid: 202
+  - uid: 201
     components:
     - type: Transform
       pos: 2.5,-7.5
       parent: 1
-  - uid: 203
+  - uid: 202
     components:
     - type: Transform
       pos: 2.5,-6.5
       parent: 1
-  - uid: 204
+  - uid: 203
     components:
     - type: Transform
       pos: 2.5,-5.5
       parent: 1
-  - uid: 205
+  - uid: 204
     components:
     - type: Transform
       pos: 2.5,-4.5
       parent: 1
-  - uid: 206
+  - uid: 205
     components:
     - type: Transform
       pos: 2.5,-3.5
       parent: 1
-  - uid: 207
+  - uid: 206
     components:
     - type: Transform
       pos: 2.5,-2.5
       parent: 1
-  - uid: 208
+  - uid: 207
     components:
     - type: Transform
       pos: 2.5,-1.5
       parent: 1
-  - uid: 209
+  - uid: 208
     components:
     - type: Transform
       pos: 2.5,-0.5
       parent: 1
-  - uid: 210
+  - uid: 209
     components:
     - type: Transform
       pos: 2.5,0.5
       parent: 1
-  - uid: 211
+  - uid: 210
     components:
     - type: Transform
       pos: 2.5,1.5
       parent: 1
-  - uid: 212
+  - uid: 211
     components:
     - type: Transform
       pos: 2.5,2.5
       parent: 1
-  - uid: 213
+  - uid: 212
     components:
     - type: Transform
       pos: 2.5,3.5
       parent: 1
-  - uid: 214
+  - uid: 213
     components:
     - type: Transform
       pos: 2.5,4.5
       parent: 1
-  - uid: 215
+  - uid: 214
     components:
     - type: Transform
       pos: 2.5,5.5
       parent: 1
-  - uid: 216
+  - uid: 215
     components:
     - type: Transform
       pos: 3.5,5.5
       parent: 1
-  - uid: 217
+  - uid: 216
     components:
     - type: Transform
       pos: 3.5,6.5
       parent: 1
-  - uid: 218
+  - uid: 217
     components:
     - type: Transform
       pos: 3.5,7.5
       parent: 1
-  - uid: 219
+  - uid: 218
     components:
     - type: Transform
       pos: 3.5,8.5
       parent: 1
-  - uid: 220
+  - uid: 219
     components:
     - type: Transform
       pos: 3.5,9.5
       parent: 1
-  - uid: 221
+  - uid: 220
     components:
     - type: Transform
       pos: 3.5,10.5
       parent: 1
-  - uid: 222
+  - uid: 221
     components:
     - type: Transform
       pos: 3.5,11.5
       parent: 1
-  - uid: 223
+  - uid: 222
     components:
     - type: Transform
       pos: 3.5,12.5
       parent: 1
-  - uid: 224
+  - uid: 223
     components:
     - type: Transform
       pos: 3.5,13.5
       parent: 1
-  - uid: 225
+  - uid: 224
     components:
     - type: Transform
       pos: 3.5,14.5
       parent: 1
-  - uid: 226
+  - uid: 225
     components:
     - type: Transform
       pos: 3.5,15.5
       parent: 1
-  - uid: 227
+  - uid: 226
     components:
     - type: Transform
       pos: 2.5,15.5
       parent: 1
-  - uid: 228
+  - uid: 227
     components:
     - type: Transform
       pos: 2.5,16.5
       parent: 1
-  - uid: 229
+  - uid: 228
     components:
     - type: Transform
       pos: -0.5,-13.5
       parent: 1
-  - uid: 230
+  - uid: 229
     components:
     - type: Transform
       pos: 1.5,-13.5
       parent: 1
 - proto: CableHVStack
   entities:
-  - uid: 231
+  - uid: 230
     components:
     - type: Transform
       pos: 0.43823814,-7.9377728
       parent: 1
 - proto: CableMV
   entities:
-  - uid: 232
+  - uid: 231
     components:
     - type: Transform
       pos: 1.5,-10.5
       parent: 1
-  - uid: 233
+  - uid: 232
     components:
     - type: Transform
       pos: 1.5,-9.5
       parent: 1
-  - uid: 234
+  - uid: 233
     components:
     - type: Transform
       pos: 0.5,-9.5
       parent: 1
-  - uid: 235
+  - uid: 234
     components:
     - type: Transform
       pos: -0.5,-9.5
       parent: 1
-  - uid: 236
+  - uid: 235
     components:
     - type: Transform
       pos: -2.5,-9.5
       parent: 1
-  - uid: 237
+  - uid: 236
     components:
     - type: Transform
       pos: -2.5,-10.5
       parent: 1
-  - uid: 238
+  - uid: 237
     components:
     - type: Transform
       pos: 2.5,-9.5
       parent: 1
-  - uid: 239
+  - uid: 238
     components:
     - type: Transform
       pos: 2.5,-8.5
       parent: 1
-  - uid: 240
+  - uid: 239
     components:
     - type: Transform
       pos: 2.5,-7.5
       parent: 1
-  - uid: 241
+  - uid: 240
     components:
     - type: Transform
       pos: 2.5,-6.5
       parent: 1
-  - uid: 242
+  - uid: 241
     components:
     - type: Transform
       pos: 2.5,-5.5
       parent: 1
-  - uid: 243
+  - uid: 242
     components:
     - type: Transform
       pos: 1.5,-5.5
       parent: 1
-  - uid: 244
+  - uid: 243
     components:
     - type: Transform
       pos: 0.5,-5.5
       parent: 1
-  - uid: 245
+  - uid: 244
     components:
     - type: Transform
       pos: -0.5,-5.5
       parent: 1
-  - uid: 246
+  - uid: 245
     components:
     - type: Transform
       pos: -0.5,-6.5
       parent: 1
-  - uid: 247
+  - uid: 246
     components:
     - type: Transform
       pos: 3.5,-5.5
       parent: 1
-  - uid: 248
+  - uid: 247
     components:
     - type: Transform
       pos: 4.5,-5.5
       parent: 1
-  - uid: 249
+  - uid: 248
     components:
     - type: Transform
       pos: 4.5,-6.5
       parent: 1
-  - uid: 250
+  - uid: 249
     components:
     - type: Transform
       pos: 2.5,-4.5
       parent: 1
-  - uid: 251
+  - uid: 250
     components:
     - type: Transform
       pos: 2.5,-3.5
       parent: 1
-  - uid: 252
+  - uid: 251
     components:
     - type: Transform
       pos: 2.5,-2.5
       parent: 1
-  - uid: 253
+  - uid: 252
     components:
     - type: Transform
       pos: 2.5,-1.5
       parent: 1
-  - uid: 254
+  - uid: 253
     components:
     - type: Transform
       pos: 2.5,-0.5
       parent: 1
-  - uid: 255
+  - uid: 254
     components:
     - type: Transform
       pos: 2.5,0.5
       parent: 1
-  - uid: 256
+  - uid: 255
     components:
     - type: Transform
       pos: 2.5,1.5
       parent: 1
-  - uid: 257
+  - uid: 256
     components:
     - type: Transform
       pos: 2.5,2.5
       parent: 1
-  - uid: 258
+  - uid: 257
     components:
     - type: Transform
       pos: 1.5,2.5
       parent: 1
-  - uid: 259
+  - uid: 258
     components:
     - type: Transform
       pos: 0.5,2.5
       parent: 1
-  - uid: 260
+  - uid: 259
     components:
     - type: Transform
       pos: -0.5,2.5
       parent: 1
-  - uid: 261
+  - uid: 260
     components:
     - type: Transform
       pos: -1.5,2.5
       parent: 1
-  - uid: 262
+  - uid: 261
     components:
     - type: Transform
       pos: -1.5,1.5
       parent: 1
-  - uid: 263
+  - uid: 262
     components:
     - type: Transform
       pos: -1.5,0.5
       parent: 1
-  - uid: 264
+  - uid: 263
     components:
     - type: Transform
       pos: 2.5,3.5
       parent: 1
-  - uid: 265
+  - uid: 264
     components:
     - type: Transform
       pos: 2.5,4.5
       parent: 1
-  - uid: 266
+  - uid: 265
     components:
     - type: Transform
       pos: 2.5,5.5
       parent: 1
-  - uid: 267
+  - uid: 266
     components:
     - type: Transform
       pos: 2.5,6.5
       parent: 1
-  - uid: 268
+  - uid: 267
     components:
     - type: Transform
       pos: 3.5,6.5
       parent: 1
-  - uid: 269
+  - uid: 268
     components:
     - type: Transform
       pos: 3.5,7.5
       parent: 1
-  - uid: 270
+  - uid: 269
     components:
     - type: Transform
       pos: 3.5,8.5
       parent: 1
-  - uid: 271
+  - uid: 270
     components:
     - type: Transform
       pos: 3.5,9.5
       parent: 1
-  - uid: 272
+  - uid: 271
     components:
     - type: Transform
       pos: 2.5,9.5
       parent: 1
-  - uid: 273
+  - uid: 272
     components:
     - type: Transform
       pos: 1.5,9.5
       parent: 1
-  - uid: 274
+  - uid: 273
     components:
     - type: Transform
       pos: 1.5,10.5
       parent: 1
-  - uid: 275
+  - uid: 274
     components:
     - type: Transform
       pos: 0.5,9.5
       parent: 1
-  - uid: 276
+  - uid: 275
     components:
     - type: Transform
       pos: -0.5,9.5
       parent: 1
-  - uid: 277
+  - uid: 276
     components:
     - type: Transform
       pos: -1.5,9.5
       parent: 1
-  - uid: 278
+  - uid: 277
     components:
     - type: Transform
       pos: -2.5,9.5
       parent: 1
-  - uid: 279
+  - uid: 278
     components:
     - type: Transform
       pos: -2.5,8.5
       parent: 1
-  - uid: 280
+  - uid: 279
     components:
     - type: Transform
       pos: -2.5,7.5
       parent: 1
-  - uid: 281
+  - uid: 280
     components:
     - type: Transform
       pos: -2.5,6.5
       parent: 1
-  - uid: 282
+  - uid: 281
     components:
     - type: Transform
       pos: -1.5,8.5
       parent: 1
-  - uid: 283
+  - uid: 282
     components:
     - type: Transform
       pos: -1.5,7.5
       parent: 1
-  - uid: 284
+  - uid: 283
     components:
     - type: Transform
       pos: 2.5,7.5
       parent: 1
-  - uid: 285
+  - uid: 284
     components:
     - type: Transform
       pos: 3.5,10.5
       parent: 1
-  - uid: 286
+  - uid: 285
     components:
     - type: Transform
       pos: 3.5,11.5
       parent: 1
-  - uid: 287
+  - uid: 286
     components:
     - type: Transform
       pos: 3.5,12.5
       parent: 1
-  - uid: 288
+  - uid: 287
     components:
     - type: Transform
       pos: 3.5,13.5
       parent: 1
-  - uid: 289
+  - uid: 288
     components:
     - type: Transform
       pos: 3.5,14.5
       parent: 1
-  - uid: 290
+  - uid: 289
     components:
     - type: Transform
       pos: 4.5,14.5
       parent: 1
-  - uid: 291
+  - uid: 290
     components:
     - type: Transform
       pos: 4.5,13.5
       parent: 1
-  - uid: 292
+  - uid: 291
     components:
     - type: Transform
       pos: 4.5,12.5
       parent: 1
-  - uid: 293
+  - uid: 292
     components:
     - type: Transform
       pos: 4.5,11.5
       parent: 1
-  - uid: 294
+  - uid: 293
     components:
     - type: Transform
       pos: 4.5,15.5
+      parent: 1
+  - uid: 294
+    components:
+    - type: Transform
+      pos: 3.5,16.5
       parent: 1
   - uid: 295
     components:
@@ -2550,270 +2548,210 @@ entities:
   - uid: 296
     components:
     - type: Transform
-      pos: 3.5,16.5
+      pos: 3.5,17.5
       parent: 1
   - uid: 297
     components:
     - type: Transform
-      pos: 3.5,17.5
+      pos: 2.5,17.5
       parent: 1
   - uid: 298
     components:
     - type: Transform
-      pos: 2.5,17.5
+      pos: 1.5,17.5
       parent: 1
   - uid: 299
     components:
     - type: Transform
-      pos: 1.5,17.5
+      pos: 0.5,17.5
       parent: 1
   - uid: 300
     components:
     - type: Transform
-      pos: 0.5,17.5
+      pos: -0.5,17.5
       parent: 1
   - uid: 301
     components:
     - type: Transform
-      pos: -0.5,17.5
+      pos: -1.5,17.5
       parent: 1
   - uid: 302
     components:
     - type: Transform
-      pos: -1.5,17.5
+      pos: -2.5,17.5
       parent: 1
   - uid: 303
     components:
     - type: Transform
-      pos: -2.5,17.5
+      pos: -2.5,16.5
       parent: 1
   - uid: 304
     components:
     - type: Transform
-      pos: -2.5,16.5
+      pos: -3.5,16.5
       parent: 1
   - uid: 305
     components:
     - type: Transform
-      pos: -3.5,16.5
+      pos: -3.5,15.5
       parent: 1
   - uid: 306
     components:
     - type: Transform
-      pos: -3.5,15.5
+      pos: -3.5,14.5
       parent: 1
   - uid: 307
     components:
     - type: Transform
-      pos: -3.5,14.5
+      pos: -3.5,13.5
       parent: 1
   - uid: 308
     components:
     - type: Transform
-      pos: -3.5,13.5
+      pos: -3.5,12.5
       parent: 1
   - uid: 309
     components:
     - type: Transform
-      pos: -3.5,12.5
-      parent: 1
-  - uid: 310
-    components:
-    - type: Transform
       pos: -3.5,11.5
       parent: 1
-  - uid: 311
+  - uid: 310
     components:
     - type: Transform
       pos: -1.5,-9.5
       parent: 1
 - proto: CableMVStack
   entities:
-  - uid: 312
+  - uid: 311
     components:
     - type: Transform
       pos: 0.36011314,-7.7815228
       parent: 1
 - proto: CableTerminal
   entities:
-  - uid: 313
+  - uid: 312
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -0.5,-11.5
       parent: 1
-- proto: CandleBlackInfinite
-  entities:
-  - uid: 314
-    components:
-    - type: Transform
-      pos: 0.43261194,-8.467525
-      parent: 1
-  - uid: 315
-    components:
-    - type: Transform
-      pos: 4.651362,-5.7018995
-      parent: 1
-- proto: CandleBlueSmallInfinite
-  entities:
-  - uid: 316
-    components:
-    - type: Transform
-      pos: 0.21386194,-8.405025
-      parent: 1
-- proto: CandlePurpleInfinite
-  entities:
-  - uid: 317
-    components:
-    - type: Transform
-      pos: 1.7583344,4.4910336
-      parent: 1
-  - uid: 318
-    components:
-    - type: Transform
-      pos: 3.2270844,5.1160336
-      parent: 1
-- proto: CandleRed
-  entities:
-  - uid: 319
-    components:
-    - type: Transform
-      pos: -1.348638,-4.4327254
-      parent: 1
-- proto: CandleRedInfinite
-  entities:
-  - uid: 320
-    components:
-    - type: Transform
-      pos: 1.2270844,4.1629086
-      parent: 1
-  - uid: 321
-    components:
-    - type: Transform
-      pos: 1.1020844,5.7254086
-      parent: 1
-  - uid: 322
-    components:
-    - type: Transform
-      pos: -1.614263,-4.4014754
-      parent: 1
 - proto: CarpetBlue
   entities:
-  - uid: 323
+  - uid: 313
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -0.5,14.5
       parent: 1
-  - uid: 324
+  - uid: 314
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -1.5,11.5
       parent: 1
-  - uid: 325
+  - uid: 315
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -1.5,12.5
       parent: 1
-  - uid: 326
+  - uid: 316
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -1.5,13.5
       parent: 1
-  - uid: 327
+  - uid: 317
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -1.5,14.5
       parent: 1
-  - uid: 328
+  - uid: 318
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -0.5,13.5
       parent: 1
-  - uid: 329
+  - uid: 319
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -0.5,12.5
       parent: 1
-  - uid: 330
+  - uid: 320
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -0.5,11.5
       parent: 1
-  - uid: 331
+  - uid: 321
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 0.5,14.5
       parent: 1
-  - uid: 332
+  - uid: 322
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 0.5,13.5
       parent: 1
-  - uid: 333
+  - uid: 323
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 0.5,12.5
       parent: 1
-  - uid: 334
+  - uid: 324
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 0.5,11.5
       parent: 1
-  - uid: 335
+  - uid: 325
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 1.5,14.5
       parent: 1
-  - uid: 336
+  - uid: 326
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 1.5,13.5
       parent: 1
-  - uid: 337
+  - uid: 327
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 1.5,12.5
       parent: 1
-  - uid: 338
+  - uid: 328
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 1.5,11.5
       parent: 1
-  - uid: 339
+  - uid: 329
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 2.5,14.5
       parent: 1
-  - uid: 340
+  - uid: 330
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 2.5,13.5
       parent: 1
-  - uid: 341
+  - uid: 331
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 2.5,12.5
       parent: 1
-  - uid: 342
+  - uid: 332
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -2821,62 +2759,62 @@ entities:
       parent: 1
 - proto: Catwalk
   entities:
-  - uid: 343
+  - uid: 333
     components:
     - type: Transform
       pos: 2.5,-8.5
       parent: 1
-  - uid: 344
+  - uid: 334
     components:
     - type: Transform
       pos: 0.5,-11.5
       parent: 1
-  - uid: 345
+  - uid: 335
     components:
     - type: Transform
       pos: 0.5,-10.5
       parent: 1
-  - uid: 346
+  - uid: 336
     components:
     - type: Transform
       pos: 2.5,-9.5
       parent: 1
-  - uid: 347
+  - uid: 337
     components:
     - type: Transform
       pos: 2.5,-7.5
       parent: 1
-  - uid: 348
+  - uid: 338
     components:
     - type: Transform
       pos: 1.5,-11.5
       parent: 1
-  - uid: 349
+  - uid: 339
     components:
     - type: Transform
       pos: -0.5,-11.5
       parent: 1
 - proto: Chair
   entities:
-  - uid: 350
+  - uid: 340
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -1.5,-7.5
       parent: 1
-  - uid: 351
+  - uid: 341
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -1.5,-8.5
       parent: 1
-  - uid: 352
+  - uid: 342
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 1.5,-7.5
       parent: 1
-  - uid: 353
+  - uid: 343
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -2884,7 +2822,7 @@ entities:
       parent: 1
 - proto: ChairOfficeDark
   entities:
-  - uid: 354
+  - uid: 344
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -2892,119 +2830,137 @@ entities:
       parent: 1
 - proto: ChairPilotSeat
   entities:
-  - uid: 355
+  - uid: 345
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -0.5,7.5
       parent: 1
-  - uid: 356
+  - uid: 346
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -0.5,8.5
       parent: 1
-  - uid: 357
+  - uid: 347
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 1.5,8.5
       parent: 1
-  - uid: 358
+  - uid: 348
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -2.5,8.5
       parent: 1
-  - uid: 359
+  - uid: 349
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -2.5,7.5
       parent: 1
-  - uid: 360
+  - uid: 350
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -0.5,11.5
       parent: 1
-  - uid: 361
+  - uid: 351
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 1.5,11.5
       parent: 1
-  - uid: 362
+  - uid: 352
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 2.5,13.5
       parent: 1
-  - uid: 363
+  - uid: 353
     components:
     - type: Transform
       pos: 1.5,14.5
       parent: 1
-  - uid: 364
+  - uid: 354
     components:
     - type: Transform
       pos: -0.5,14.5
       parent: 1
-  - uid: 365
+  - uid: 355
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -1.5,12.5
       parent: 1
-  - uid: 366
+  - uid: 356
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 1.5,5.5
+      parent: 1
+  - uid: 357
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 1.5,4.5
+      parent: 1
+  - uid: 358
+    components:
+    - type: Transform
+      rot: 1.5707963267948966 rad
+      pos: 1.5,3.5
+      parent: 1
+  - uid: 359
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 2.5,-1.5
       parent: 1
-  - uid: 367
+  - uid: 360
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 2.5,-2.5
       parent: 1
-  - uid: 368
+  - uid: 361
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 2.5,-3.5
       parent: 1
-  - uid: 369
+  - uid: 362
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 2.5,-4.5
       parent: 1
-  - uid: 370
+  - uid: 363
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 3.5,-1.5
       parent: 1
-  - uid: 371
+  - uid: 364
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 3.5,-2.5
       parent: 1
-  - uid: 372
+  - uid: 365
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 3.5,-3.5
       parent: 1
-  - uid: 373
+  - uid: 366
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 3.5,-4.5
       parent: 1
-  - uid: 374
+  - uid: 367
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -3012,28 +2968,28 @@ entities:
       parent: 1
 - proto: ChemDispenser
   entities:
-  - uid: 375
+  - uid: 368
     components:
     - type: Transform
       pos: -2.5,5.5
       parent: 1
 - proto: ChemMaster
   entities:
-  - uid: 376
+  - uid: 369
     components:
     - type: Transform
       pos: -3.5,5.5
       parent: 1
 - proto: ChessBoard
   entities:
-  - uid: 377
+  - uid: 370
     components:
     - type: Transform
       pos: 0.44824982,13.574413
       parent: 1
 - proto: ClosetWallEmergencyFilledRandom
   entities:
-  - uid: 378
+  - uid: 371
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -3045,8 +3001,8 @@ entities:
           showEnts: False
           occludes: True
           ents:
-          - 379
-  - uid: 380
+          - 372
+  - uid: 373
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -3058,8 +3014,8 @@ entities:
           showEnts: False
           occludes: True
           ents:
-          - 381
-  - uid: 382
+          - 374
+  - uid: 375
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -3071,8 +3027,8 @@ entities:
           showEnts: False
           occludes: True
           ents:
-          - 383
-  - uid: 384
+          - 376
+  - uid: 377
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -3084,10 +3040,10 @@ entities:
           showEnts: False
           occludes: True
           ents:
-          - 385
+          - 378
 - proto: ClosetWallFireFilledRandom
   entities:
-  - uid: 386
+  - uid: 379
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -3099,8 +3055,8 @@ entities:
           showEnts: False
           occludes: True
           ents:
-          - 387
-  - uid: 388
+          - 380
+  - uid: 381
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -3112,8 +3068,8 @@ entities:
           showEnts: False
           occludes: True
           ents:
-          - 389
-  - uid: 390
+          - 382
+  - uid: 383
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -3125,10 +3081,10 @@ entities:
           showEnts: False
           occludes: True
           ents:
-          - 391
+          - 384
 - proto: ClosetWallOrange
   entities:
-  - uid: 392
+  - uid: 385
     components:
     - type: Transform
       pos: -2.5,10.5
@@ -3139,10 +3095,10 @@ entities:
           showEnts: False
           occludes: True
           ents:
-          - 394
-          - 393
-          - 395
-          - 396
+          - 387
+          - 386
+          - 388
+          - 389
 - proto: ClothingOuterSuitRad
   entities:
   - uid: 11
@@ -3161,53 +3117,53 @@ entities:
     - type: InsideEntityStorage
 - proto: ClothingUniformJumpskirtPrisoner
   entities:
-  - uid: 393
+  - uid: 386
     components:
     - type: Transform
-      parent: 392
+      parent: 385
     - type: Physics
       canCollide: False
     - type: InsideEntityStorage
-  - uid: 394
+  - uid: 387
     components:
     - type: Transform
-      parent: 392
+      parent: 385
     - type: Physics
       canCollide: False
     - type: InsideEntityStorage
 - proto: ClothingUniformJumpsuitPrisoner
   entities:
-  - uid: 395
+  - uid: 388
     components:
     - type: Transform
-      parent: 392
+      parent: 385
     - type: Physics
       canCollide: False
     - type: InsideEntityStorage
-  - uid: 396
+  - uid: 389
     components:
     - type: Transform
-      parent: 392
+      parent: 385
     - type: Physics
       canCollide: False
     - type: InsideEntityStorage
 - proto: ComputerComms
   entities:
-  - uid: 397
+  - uid: 390
     components:
     - type: Transform
       pos: -0.5,16.5
       parent: 1
 - proto: ComputerEmergencyShuttle
   entities:
-  - uid: 398
+  - uid: 391
     components:
     - type: Transform
       pos: 0.5,16.5
       parent: 1
 - proto: ComputerId
   entities:
-  - uid: 399
+  - uid: 392
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -3215,21 +3171,21 @@ entities:
       parent: 1
 - proto: ComputerPowerMonitoring
   entities:
-  - uid: 400
+  - uid: 393
     components:
     - type: Transform
       pos: 2.5,16.5
       parent: 1
 - proto: ComputerRadar
   entities:
-  - uid: 401
+  - uid: 394
     components:
     - type: Transform
       pos: -1.5,16.5
       parent: 1
 - proto: ComputerShuttle
   entities:
-  - uid: 402
+  - uid: 395
     components:
     - type: Transform
       pos: 1.5,16.5
@@ -3261,33 +3217,14 @@ entities:
           ent: null
 - proto: DefibrillatorCabinetFilled
   entities:
-  - uid: 403
+  - uid: 396
     components:
     - type: Transform
       pos: -1.5,6.5
       parent: 1
-- proto: DrinkDriestMartiniGlass
-  entities:
-  - uid: 404
-    components:
-    - type: Transform
-      pos: -1.333013,-3.8608599
-      parent: 1
-- proto: DrinkHotCoco
-  entities:
-  - uid: 405
-    components:
-    - type: Transform
-      pos: -1.629888,-3.2046099
-      parent: 1
-  - uid: 406
-    components:
-    - type: Transform
-      pos: -1.286138,-3.3608599
-      parent: 1
 - proto: FireAxeCabinetFilled
   entities:
-  - uid: 407
+  - uid: 397
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -3295,7 +3232,7 @@ entities:
       parent: 1
 - proto: FirelockEdge
   entities:
-  - uid: 408
+  - uid: 398
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -3305,7 +3242,7 @@ entities:
       deviceLists:
       - 15
       - 16
-  - uid: 409
+  - uid: 399
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -3315,7 +3252,7 @@ entities:
       deviceLists:
       - 15
       - 16
-  - uid: 410
+  - uid: 400
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -3325,7 +3262,7 @@ entities:
       deviceLists:
       - 15
       - 16
-  - uid: 411
+  - uid: 401
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -3335,7 +3272,7 @@ entities:
       deviceLists:
       - 15
       - 16
-  - uid: 412
+  - uid: 402
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -3345,7 +3282,7 @@ entities:
       deviceLists:
       - 15
       - 16
-  - uid: 413
+  - uid: 403
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -3357,7 +3294,7 @@ entities:
       - 16
 - proto: FirelockGlass
   entities:
-  - uid: 414
+  - uid: 404
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -3367,7 +3304,7 @@ entities:
       deviceLists:
       - 15
       - 21
-  - uid: 415
+  - uid: 405
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -3377,7 +3314,7 @@ entities:
       deviceLists:
       - 15
       - 21
-  - uid: 416
+  - uid: 406
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -3387,7 +3324,7 @@ entities:
       deviceLists:
       - 15
       - 21
-  - uid: 417
+  - uid: 407
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -3397,7 +3334,7 @@ entities:
       deviceLists:
       - 15
       - 21
-  - uid: 418
+  - uid: 408
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -3406,7 +3343,7 @@ entities:
     - type: DeviceNetwork
       deviceLists:
       - 21
-  - uid: 419
+  - uid: 409
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -3415,7 +3352,7 @@ entities:
     - type: DeviceNetwork
       deviceLists:
       - 21
-  - uid: 420
+  - uid: 410
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -3425,7 +3362,7 @@ entities:
       deviceLists:
       - 21
       - 17
-  - uid: 421
+  - uid: 411
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -3435,7 +3372,7 @@ entities:
       deviceLists:
       - 21
       - 17
-  - uid: 422
+  - uid: 412
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -3445,7 +3382,7 @@ entities:
       deviceLists:
       - 18
       - 20
-  - uid: 423
+  - uid: 413
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -3455,7 +3392,7 @@ entities:
       deviceLists:
       - 21
       - 18
-  - uid: 424
+  - uid: 414
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -3465,7 +3402,7 @@ entities:
       deviceLists:
       - 21
       - 19
-  - uid: 425
+  - uid: 415
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -3475,64 +3412,34 @@ entities:
       deviceLists:
       - 22
       - 15
-- proto: FloraTreeChristmas02
-  entities:
-  - uid: 426
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 1.9927094,4.8816586
-      parent: 1
 - proto: FoodBoxPizzaFilled
   entities:
-  - uid: 427
+  - uid: 416
     components:
     - type: Transform
       pos: -2.5048752,13.66442
       parent: 1
-- proto: FoodCakeChristmas
-  entities:
-  - uid: 428
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: -1.5325987,-2.1404784
-      parent: 1
-- proto: FoodPlate
-  entities:
-  - uid: 429
-    components:
-    - type: Transform
-      pos: -1.504888,-1.9702349
-      parent: 1
-- proto: FoodSnackSyndi
-  entities:
-  - uid: 430
-    components:
-    - type: Transform
-      pos: -1.489263,-2.6577349
-      parent: 1
 - proto: GasPipeBend
   entities:
-  - uid: 431
+  - uid: 417
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 2.5,-9.5
       parent: 1
-  - uid: 432
+  - uid: 418
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 2.5,5.5
       parent: 1
-  - uid: 433
+  - uid: 419
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 3.5,5.5
       parent: 1
-  - uid: 434
+  - uid: 420
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -3540,160 +3447,160 @@ entities:
       parent: 1
 - proto: GasPipeStraight
   entities:
-  - uid: 435
+  - uid: 421
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 1.5,-9.5
       parent: 1
-  - uid: 436
+  - uid: 422
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 0.5,-9.5
       parent: 1
-  - uid: 437
+  - uid: 423
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -0.5,-9.5
       parent: 1
-  - uid: 438
+  - uid: 424
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 2.5,-7.5
       parent: 1
-  - uid: 439
+  - uid: 425
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 2.5,-6.5
       parent: 1
-  - uid: 440
+  - uid: 426
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 2.5,-5.5
       parent: 1
-  - uid: 441
+  - uid: 427
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 2.5,-3.5
       parent: 1
-  - uid: 442
+  - uid: 428
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 2.5,-2.5
       parent: 1
-  - uid: 443
+  - uid: 429
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 2.5,-1.5
       parent: 1
-  - uid: 444
+  - uid: 430
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 2.5,0.5
       parent: 1
-  - uid: 445
+  - uid: 431
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 2.5,4.5
       parent: 1
-  - uid: 446
+  - uid: 432
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 2.5,3.5
       parent: 1
-  - uid: 447
+  - uid: 433
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 3.5,6.5
       parent: 1
-  - uid: 448
+  - uid: 434
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 3.5,7.5
       parent: 1
-  - uid: 449
+  - uid: 435
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 3.5,8.5
       parent: 1
-  - uid: 450
+  - uid: 436
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 2.5,9.5
       parent: 1
-  - uid: 451
+  - uid: 437
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 1.5,9.5
       parent: 1
-  - uid: 452
+  - uid: 438
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -0.5,9.5
       parent: 1
-  - uid: 453
+  - uid: 439
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -1.5,9.5
       parent: 1
-  - uid: 454
+  - uid: 440
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -2.5,9.5
       parent: 1
-  - uid: 455
+  - uid: 441
     components:
     - type: Transform
       pos: 3.5,10.5
       parent: 1
-  - uid: 456
+  - uid: 442
     components:
     - type: Transform
       pos: 3.5,11.5
       parent: 1
-  - uid: 457
+  - uid: 443
     components:
     - type: Transform
       pos: 3.5,12.5
       parent: 1
-  - uid: 458
+  - uid: 444
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -0.5,2.5
       parent: 1
-  - uid: 459
+  - uid: 445
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 0.5,2.5
       parent: 1
-  - uid: 460
+  - uid: 446
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 1.5,2.5
       parent: 1
-  - uid: 461
+  - uid: 447
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -3701,50 +3608,50 @@ entities:
       parent: 1
 - proto: GasPipeTJunction
   entities:
-  - uid: 462
+  - uid: 448
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 2.5,-8.5
       parent: 1
-  - uid: 463
+  - uid: 449
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 2.5,-4.5
       parent: 1
-  - uid: 464
+  - uid: 450
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 2.5,-0.5
       parent: 1
-  - uid: 465
+  - uid: 451
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 2.5,1.5
       parent: 1
-  - uid: 466
+  - uid: 452
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 2.5,2.5
       parent: 1
-  - uid: 467
+  - uid: 453
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 3.5,9.5
       parent: 1
-  - uid: 468
+  - uid: 454
     components:
     - type: Transform
       pos: 0.5,9.5
       parent: 1
 - proto: GasPort
   entities:
-  - uid: 469
+  - uid: 455
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -3752,7 +3659,7 @@ entities:
       parent: 1
 - proto: GasPressurePump
   entities:
-  - uid: 470
+  - uid: 456
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -3760,7 +3667,7 @@ entities:
       parent: 1
 - proto: GasVentPump
   entities:
-  - uid: 471
+  - uid: 457
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -3769,7 +3676,7 @@ entities:
     - type: DeviceNetwork
       deviceLists:
       - 16
-  - uid: 472
+  - uid: 458
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -3778,7 +3685,7 @@ entities:
     - type: DeviceNetwork
       deviceLists:
       - 15
-  - uid: 473
+  - uid: 459
     components:
     - type: Transform
       pos: 3.5,13.5
@@ -3786,7 +3693,7 @@ entities:
     - type: DeviceNetwork
       deviceLists:
       - 19
-  - uid: 474
+  - uid: 460
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -3795,7 +3702,7 @@ entities:
     - type: DeviceNetwork
       deviceLists:
       - 18
-  - uid: 475
+  - uid: 461
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -3804,7 +3711,7 @@ entities:
     - type: DeviceNetwork
       deviceLists:
       - 20
-  - uid: 476
+  - uid: 462
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -3813,7 +3720,7 @@ entities:
     - type: DeviceNetwork
       deviceLists:
       - 17
-  - uid: 477
+  - uid: 463
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -3822,7 +3729,7 @@ entities:
     - type: DeviceNetwork
       deviceLists:
       - 21
-  - uid: 478
+  - uid: 464
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -3849,211 +3756,211 @@ entities:
     - type: InsideEntityStorage
 - proto: GeneratorWallmountAPU
   entities:
-  - uid: 479
+  - uid: 465
     components:
     - type: Transform
       pos: -0.5,-13.5
       parent: 1
-  - uid: 480
+  - uid: 466
     components:
     - type: Transform
       pos: 1.5,-13.5
       parent: 1
 - proto: GravityGeneratorMini
   entities:
-  - uid: 481
+  - uid: 467
     components:
     - type: Transform
       pos: 3.5,-8.5
       parent: 1
 - proto: Grille
   entities:
-  - uid: 482
+  - uid: 468
     components:
     - type: Transform
       pos: -4.5,-2.5
       parent: 1
-  - uid: 483
+  - uid: 469
     components:
     - type: Transform
       pos: -4.5,-3.5
       parent: 1
-  - uid: 484
+  - uid: 470
     components:
     - type: Transform
       pos: -4.5,-4.5
       parent: 1
-  - uid: 485
+  - uid: 471
     components:
     - type: Transform
       pos: 5.5,7.5
       parent: 1
-  - uid: 486
+  - uid: 472
     components:
     - type: Transform
       pos: 5.5,8.5
       parent: 1
-  - uid: 487
+  - uid: 473
     components:
     - type: Transform
       pos: 5.5,1.5
       parent: 1
-  - uid: 488
+  - uid: 474
     components:
     - type: Transform
       pos: 5.5,-0.5
       parent: 1
-  - uid: 489
+  - uid: 475
     components:
     - type: Transform
       pos: 4.5,11.5
       parent: 1
-  - uid: 490
+  - uid: 476
     components:
     - type: Transform
       pos: 4.5,12.5
       parent: 1
-  - uid: 491
+  - uid: 477
     components:
     - type: Transform
       pos: 4.5,13.5
       parent: 1
-  - uid: 492
+  - uid: 478
     components:
     - type: Transform
       pos: 4.5,15.5
       parent: 1
-  - uid: 493
+  - uid: 479
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -1.5,17.5
       parent: 1
-  - uid: 494
+  - uid: 480
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -0.5,17.5
       parent: 1
-  - uid: 495
+  - uid: 481
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 0.5,17.5
       parent: 1
-  - uid: 496
+  - uid: 482
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 1.5,17.5
       parent: 1
-  - uid: 497
+  - uid: 483
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 2.5,17.5
       parent: 1
-  - uid: 498
+  - uid: 484
     components:
     - type: Transform
       pos: -3.5,15.5
       parent: 1
-  - uid: 499
+  - uid: 485
     components:
     - type: Transform
       pos: -3.5,13.5
       parent: 1
-  - uid: 500
+  - uid: 486
     components:
     - type: Transform
       pos: -3.5,12.5
       parent: 1
-  - uid: 501
+  - uid: 487
     components:
     - type: Transform
       pos: -3.5,11.5
       parent: 1
-  - uid: 502
+  - uid: 488
     components:
     - type: Transform
       pos: -4.5,2.5
       parent: 1
-  - uid: 503
+  - uid: 489
     components:
     - type: Transform
       pos: -4.5,3.5
       parent: 1
-  - uid: 504
+  - uid: 490
     components:
     - type: Transform
       pos: -4.5,4.5
       parent: 1
-  - uid: 505
+  - uid: 491
     components:
     - type: Transform
       pos: -1.5,8.5
       parent: 1
-  - uid: 506
+  - uid: 492
     components:
     - type: Transform
       pos: -1.5,7.5
       parent: 1
-  - uid: 507
+  - uid: 493
     components:
     - type: Transform
       pos: -0.5,6.5
       parent: 1
-  - uid: 508
+  - uid: 494
     components:
     - type: Transform
       pos: 0.5,5.5
       parent: 1
-  - uid: 509
+  - uid: 495
     components:
     - type: Transform
       pos: 0.5,4.5
       parent: 1
-  - uid: 510
+  - uid: 496
     components:
     - type: Transform
       pos: 0.5,3.5
       parent: 1
-  - uid: 511
+  - uid: 497
     components:
     - type: Transform
       pos: 2.5,7.5
       parent: 1
-  - uid: 512
+  - uid: 498
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -3.5,-7.5
       parent: 1
-  - uid: 513
+  - uid: 499
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -3.5,-8.5
       parent: 1
-  - uid: 514
+  - uid: 500
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 4.5,-7.5
       parent: 1
-  - uid: 515
+  - uid: 501
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 4.5,-8.5
       parent: 1
-  - uid: 516
+  - uid: 502
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -1.5,-12.5
       parent: 1
-  - uid: 517
+  - uid: 503
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -4061,43 +3968,43 @@ entities:
       parent: 1
 - proto: GrilleDiagonal
   entities:
-  - uid: 518
+  - uid: 504
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 4.5,16.5
       parent: 1
-  - uid: 519
+  - uid: 505
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 3.5,16.5
       parent: 1
-  - uid: 520
+  - uid: 506
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 3.5,17.5
       parent: 1
-  - uid: 521
+  - uid: 507
     components:
     - type: Transform
       pos: -2.5,17.5
       parent: 1
-  - uid: 522
+  - uid: 508
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -2.5,16.5
       parent: 1
-  - uid: 523
+  - uid: 509
     components:
     - type: Transform
       pos: -3.5,16.5
       parent: 1
 - proto: Gyroscope
   entities:
-  - uid: 524
+  - uid: 510
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -4105,29 +4012,29 @@ entities:
       parent: 1
 - proto: KitchenMicrowave
   entities:
-  - uid: 525
+  - uid: 511
     components:
     - type: Transform
       pos: -2.5,12.5
       parent: 1
 - proto: LockableButtonBrig
   entities:
-  - uid: 526
+  - uid: 512
     components:
     - type: Transform
       pos: 0.5,10.5
       parent: 1
     - type: DeviceLinkSource
       linkedPorts:
-        590:
+        572:
         - Pressed: Toggle
-        591:
+        573:
         - Pressed: Toggle
-        592:
+        574:
         - Pressed: Toggle
 - proto: LockableButtonEngineering
   entities:
-  - uid: 527
+  - uid: 513
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -4135,102 +4042,102 @@ entities:
       parent: 1
     - type: DeviceLinkSource
       linkedPorts:
-        543:
+        529:
         - Pressed: DoorBolt
 - proto: LockerChemistryFilled
   entities:
-  - uid: 528
+  - uid: 514
     components:
     - type: Transform
       pos: -2.5,1.5
       parent: 1
 - proto: LockerMedicineFilled
   entities:
-  - uid: 529
+  - uid: 515
     components:
     - type: Transform
       pos: -1.5,1.5
       parent: 1
 - proto: MedicalBed
   entities:
-  - uid: 530
+  - uid: 516
     components:
     - type: Transform
       pos: -0.5,5.5
       parent: 1
-  - uid: 531
+  - uid: 517
     components:
     - type: Transform
       pos: -0.5,4.5
       parent: 1
 - proto: MedkitFilled
   entities:
-  - uid: 532
+  - uid: 518
     components:
     - type: Transform
       pos: -3.5451293,2.7365134
       parent: 1
 - proto: MedkitOxygenFilled
   entities:
-  - uid: 533
+  - uid: 519
     components:
     - type: Transform
       pos: -3.4201293,2.5646384
       parent: 1
 - proto: NitrogenTankFilled
   entities:
-  - uid: 379
+  - uid: 372
     components:
     - type: Transform
-      parent: 378
+      parent: 371
     - type: Physics
       canCollide: False
     - type: InsideEntityStorage
-  - uid: 381
+  - uid: 374
     components:
     - type: Transform
-      parent: 380
+      parent: 373
     - type: Physics
       canCollide: False
     - type: InsideEntityStorage
-  - uid: 383
+  - uid: 376
     components:
     - type: Transform
-      parent: 382
+      parent: 375
     - type: Physics
       canCollide: False
     - type: InsideEntityStorage
-  - uid: 385
+  - uid: 378
     components:
     - type: Transform
-      parent: 384
+      parent: 377
     - type: Physics
       canCollide: False
     - type: InsideEntityStorage
-  - uid: 387
+  - uid: 380
     components:
     - type: Transform
-      parent: 386
+      parent: 379
     - type: Physics
       canCollide: False
     - type: InsideEntityStorage
-  - uid: 389
+  - uid: 382
     components:
     - type: Transform
-      parent: 388
+      parent: 381
     - type: Physics
       canCollide: False
     - type: InsideEntityStorage
-  - uid: 391
+  - uid: 384
     components:
     - type: Transform
-      parent: 390
+      parent: 383
     - type: Physics
       canCollide: False
     - type: InsideEntityStorage
 - proto: PaintingAmogusTriptych
   entities:
-  - uid: 534
+  - uid: 520
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -4238,51 +4145,51 @@ entities:
       parent: 1
 - proto: PaperBin10
   entities:
-  - uid: 535
+  - uid: 521
     components:
     - type: Transform
       pos: 1.5,13.5
       parent: 1
 - proto: Pen
   entities:
-  - uid: 536
+  - uid: 522
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -0.33300018,12.761913
       parent: 1
-  - uid: 537
+  - uid: 523
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 1.3701248,12.746288
       parent: 1
-  - uid: 538
+  - uid: 524
     components:
     - type: Transform
       pos: 0.9638748,13.496288
       parent: 1
 - proto: PlasmaReinforcedWindowDirectional
   entities:
-  - uid: 539
+  - uid: 525
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -0.5,-10.5
       parent: 1
-  - uid: 540
+  - uid: 526
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -0.5,-10.5
       parent: 1
-  - uid: 541
+  - uid: 527
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 1.5,-10.5
       parent: 1
-  - uid: 542
+  - uid: 528
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -4352,29 +4259,15 @@ entities:
     - type: InsideEntityStorage
 - proto: PlasmaWindoorSecureEngineeringLocked
   entities:
-  - uid: 543
+  - uid: 529
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 0.5,-10.5
       parent: 1
-- proto: PlushieHampter
-  entities:
-  - uid: 544
-    components:
-    - type: Transform
-      pos: 3.651362,-2.5367439
-      parent: 1
-- proto: PlushieLizard
-  entities:
-  - uid: 545
-    components:
-    - type: Transform
-      pos: 2.416987,-4.505494
-      parent: 1
 - proto: PowerCellRecharger
   entities:
-  - uid: 546
+  - uid: 530
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -4382,121 +4275,121 @@ entities:
       parent: 1
 - proto: Poweredlight
   entities:
-  - uid: 547
+  - uid: 531
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 4.5,2.5
       parent: 1
-  - uid: 548
+  - uid: 532
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 4.5,-5.5
       parent: 1
-  - uid: 549
+  - uid: 533
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 0.5,-5.5
       parent: 1
-  - uid: 550
+  - uid: 534
     components:
     - type: Transform
       pos: -0.5,-0.5
       parent: 1
-  - uid: 551
+  - uid: 535
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -2.5,-5.5
       parent: 1
-  - uid: 552
+  - uid: 536
     components:
     - type: Transform
       pos: -3.5,-0.5
       parent: 1
-  - uid: 553
+  - uid: 537
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -3.5,1.5
       parent: 1
-  - uid: 554
+  - uid: 538
     components:
     - type: Transform
       pos: -2.5,5.5
       parent: 1
-  - uid: 555
+  - uid: 539
     components:
     - type: Transform
       pos: 1.5,5.5
       parent: 1
-  - uid: 556
+  - uid: 540
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 4.5,6.5
       parent: 1
-  - uid: 557
+  - uid: 541
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 4.5,9.5
       parent: 1
-  - uid: 558
+  - uid: 542
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 1.5,7.5
       parent: 1
-  - uid: 559
+  - uid: 543
     components:
     - type: Transform
       pos: -2.5,9.5
       parent: 1
-  - uid: 560
+  - uid: 544
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -3.5,7.5
       parent: 1
-  - uid: 561
+  - uid: 545
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 0.5,11.5
       parent: 1
-  - uid: 562
+  - uid: 546
     components:
     - type: Transform
       pos: -1.5,16.5
       parent: 1
-  - uid: 563
+  - uid: 547
     components:
     - type: Transform
       pos: 2.5,16.5
       parent: 1
-  - uid: 564
+  - uid: 548
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 3.5,-9.5
       parent: 1
-  - uid: 565
+  - uid: 549
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -2.5,-9.5
       parent: 1
-  - uid: 566
+  - uid: 550
     components:
     - type: Transform
       pos: 0.5,-7.5
       parent: 1
 - proto: PoweredlightGreen
   entities:
-  - uid: 567
+  - uid: 551
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -4504,85 +4397,73 @@ entities:
       parent: 1
 - proto: PoweredlightSodium
   entities:
-  - uid: 568
+  - uid: 552
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 5.5,14.5
       parent: 1
-  - uid: 569
+  - uid: 553
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -4.5,14.5
       parent: 1
-  - uid: 570
+  - uid: 554
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -4.5,-9.5
       parent: 1
-  - uid: 571
+  - uid: 555
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 5.5,-9.5
       parent: 1
-  - uid: 572
+  - uid: 556
     components:
     - type: Transform
       pos: 4.5,-11.5
       parent: 1
-  - uid: 573
+  - uid: 557
     components:
     - type: Transform
       pos: -3.5,-11.5
       parent: 1
-- proto: PresentRandom
-  entities:
-  - uid: 574
-    components:
-    - type: Transform
-      pos: 1.3677094,4.6785336
-      parent: 1
-  - uid: 575
-    components:
-    - type: Transform
-      pos: 3.0083344,5.6472836
-      parent: 1
 - proto: RadiationCollectorFullTankActive
   entities:
-  - uid: 576
+  - uid: 558
     components:
     - type: Transform
       pos: 1.5,-12.5
       parent: 1
-  - uid: 577
+  - uid: 559
     components:
     - type: Transform
       pos: -0.5,-12.5
       parent: 1
 - proto: RandomPosterLegit
   entities:
-  - uid: 578
+  - uid: 560
     components:
     - type: Transform
       pos: -3.5,0.5
       parent: 1
-  - uid: 579
+  - uid: 561
     components:
     - type: Transform
       pos: -2.5,-6.5
       parent: 1
 - proto: ReinforcedPlasmaWindow
   entities:
-  - uid: 580
+  - uid: 562
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -1.5,-12.5
       parent: 1
-  - uid: 581
+  - uid: 563
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -4590,18 +4471,18 @@ entities:
       parent: 1
 - proto: Screen
   entities:
-  - uid: 582
+  - uid: 564
     components:
     - type: Transform
       pos: 0.5,0.5
       parent: 1
-  - uid: 583
+  - uid: 565
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 0.5,-6.5
       parent: 1
-  - uid: 584
+  - uid: 566
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -4609,21 +4490,21 @@ entities:
       parent: 1
 - proto: SheetPlasteel
   entities:
-  - uid: 585
+  - uid: 567
     components:
     - type: Transform
       pos: -0.40551186,-7.4065228
       parent: 1
 - proto: SheetSteel
   entities:
-  - uid: 586
+  - uid: 568
     components:
     - type: Transform
       pos: -0.31176186,-7.6565228
       parent: 1
 - proto: ShelfBar
   entities:
-  - uid: 587
+  - uid: 569
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -4631,7 +4512,7 @@ entities:
       parent: 1
 - proto: ShelfChemistryChemistrySecure
   entities:
-  - uid: 588
+  - uid: 570
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -4639,7 +4520,7 @@ entities:
       parent: 1
 - proto: ShotGunCabinetFilled
   entities:
-  - uid: 589
+  - uid: 571
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -4647,19 +4528,19 @@ entities:
       parent: 1
 - proto: ShuttersWindow
   entities:
-  - uid: 590
+  - uid: 572
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -4.5,9.5
       parent: 1
-  - uid: 591
+  - uid: 573
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -4.5,8.5
       parent: 1
-  - uid: 592
+  - uid: 574
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -4667,205 +4548,205 @@ entities:
       parent: 1
 - proto: ShuttleWindow
   entities:
-  - uid: 593
+  - uid: 575
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -3.5,-7.5
       parent: 1
-  - uid: 594
+  - uid: 576
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -3.5,-8.5
       parent: 1
-  - uid: 595
+  - uid: 577
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 4.5,-8.5
       parent: 1
-  - uid: 596
+  - uid: 578
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 4.5,-7.5
       parent: 1
-  - uid: 597
+  - uid: 579
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 5.5,-0.5
       parent: 1
-  - uid: 598
+  - uid: 580
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -4.5,-4.5
       parent: 1
-  - uid: 599
+  - uid: 581
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -4.5,-3.5
       parent: 1
-  - uid: 600
+  - uid: 582
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -4.5,-2.5
       parent: 1
-  - uid: 601
+  - uid: 583
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 5.5,1.5
       parent: 1
-  - uid: 602
+  - uid: 584
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 0.5,3.5
       parent: 1
-  - uid: 603
+  - uid: 585
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 0.5,4.5
       parent: 1
-  - uid: 604
+  - uid: 586
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 0.5,5.5
       parent: 1
-  - uid: 605
+  - uid: 587
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -4.5,2.5
       parent: 1
-  - uid: 606
+  - uid: 588
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -4.5,3.5
       parent: 1
-  - uid: 607
+  - uid: 589
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -4.5,4.5
       parent: 1
-  - uid: 608
+  - uid: 590
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -0.5,6.5
       parent: 1
-  - uid: 609
+  - uid: 591
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -1.5,7.5
       parent: 1
-  - uid: 610
+  - uid: 592
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -1.5,8.5
       parent: 1
-  - uid: 611
+  - uid: 593
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 2.5,7.5
       parent: 1
-  - uid: 612
+  - uid: 594
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 5.5,7.5
       parent: 1
-  - uid: 613
+  - uid: 595
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 5.5,8.5
       parent: 1
-  - uid: 614
+  - uid: 596
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 4.5,11.5
       parent: 1
-  - uid: 615
+  - uid: 597
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 4.5,12.5
       parent: 1
-  - uid: 616
+  - uid: 598
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 4.5,13.5
       parent: 1
-  - uid: 617
+  - uid: 599
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -3.5,11.5
       parent: 1
-  - uid: 618
+  - uid: 600
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -3.5,12.5
       parent: 1
-  - uid: 619
+  - uid: 601
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -3.5,13.5
       parent: 1
-  - uid: 620
+  - uid: 602
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -3.5,15.5
       parent: 1
-  - uid: 621
+  - uid: 603
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -1.5,17.5
       parent: 1
-  - uid: 622
+  - uid: 604
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -0.5,17.5
       parent: 1
-  - uid: 623
+  - uid: 605
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 0.5,17.5
       parent: 1
-  - uid: 624
+  - uid: 606
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 1.5,17.5
       parent: 1
-  - uid: 625
+  - uid: 607
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 2.5,17.5
       parent: 1
-  - uid: 626
+  - uid: 608
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -4873,43 +4754,43 @@ entities:
       parent: 1
 - proto: ShuttleWindowDiagonal
   entities:
-  - uid: 627
+  - uid: 609
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 3.5,17.5
       parent: 1
-  - uid: 628
+  - uid: 610
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 4.5,16.5
       parent: 1
-  - uid: 629
+  - uid: 611
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 3.5,16.5
       parent: 1
-  - uid: 630
+  - uid: 612
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -2.5,16.5
       parent: 1
-  - uid: 631
+  - uid: 613
     components:
     - type: Transform
       pos: -3.5,16.5
       parent: 1
-  - uid: 632
+  - uid: 614
     components:
     - type: Transform
       pos: -2.5,17.5
       parent: 1
 - proto: SignBar
   entities:
-  - uid: 633
+  - uid: 615
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -4917,7 +4798,7 @@ entities:
       parent: 1
 - proto: SignBridge
   entities:
-  - uid: 634
+  - uid: 616
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -4925,7 +4806,7 @@ entities:
       parent: 1
 - proto: SignEngineering
   entities:
-  - uid: 635
+  - uid: 617
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -4933,26 +4814,26 @@ entities:
       parent: 1
 - proto: SignRadiationMed
   entities:
-  - uid: 636
+  - uid: 618
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -1.5,-11.5
       parent: 1
-  - uid: 637
+  - uid: 619
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 2.5,-11.5
       parent: 1
-  - uid: 638
+  - uid: 620
     components:
     - type: Transform
       pos: 0.5,-13.5
       parent: 1
 - proto: SignSecureSmallRed
   entities:
-  - uid: 639
+  - uid: 621
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -4960,13 +4841,13 @@ entities:
       parent: 1
 - proto: SignShipDock
   entities:
-  - uid: 640
+  - uid: 622
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 5.5,4.5
       parent: 1
-  - uid: 641
+  - uid: 623
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -4974,7 +4855,7 @@ entities:
       parent: 1
 - proto: SingularityToy
   entities:
-  - uid: 642
+  - uid: 624
     components:
     - type: MetaData
       desc: The lot down at R&D realy have gone insane. Its a miniaturized singulo just stable enough to get you home.
@@ -4990,7 +4871,7 @@ entities:
       maxRange: 2
 - proto: SMESBasic
   entities:
-  - uid: 643
+  - uid: 625
     components:
     - type: Transform
       pos: -0.5,-10.5
@@ -5000,40 +4881,33 @@ entities:
       maxCharge: 20000000
 - proto: SodaDispenser
   entities:
-  - uid: 644
+  - uid: 626
     components:
     - type: Transform
       pos: -2.5,-0.5
       parent: 1
-- proto: SpawnMobCatKitten
-  entities:
-  - uid: 645
-    components:
-    - type: Transform
-      pos: 0.5,-3.5
-      parent: 1
 - proto: StasisBed
   entities:
-  - uid: 646
+  - uid: 627
     components:
     - type: Transform
       pos: -0.5,3.5
       parent: 1
 - proto: StoolBar
   entities:
-  - uid: 647
+  - uid: 628
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -0.5,-4.5
       parent: 1
-  - uid: 648
+  - uid: 629
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -0.5,-3.5
       parent: 1
-  - uid: 649
+  - uid: 630
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -5041,106 +4915,106 @@ entities:
       parent: 1
 - proto: SubstationBasic
   entities:
-  - uid: 650
+  - uid: 631
     components:
     - type: Transform
       pos: 1.5,-10.5
       parent: 1
 - proto: TableCarpet
   entities:
-  - uid: 651
+  - uid: 632
     components:
     - type: Transform
       pos: -0.5,13.5
       parent: 1
-  - uid: 652
+  - uid: 633
     components:
     - type: Transform
       pos: -0.5,12.5
       parent: 1
-  - uid: 653
+  - uid: 634
     components:
     - type: Transform
       pos: 0.5,13.5
       parent: 1
-  - uid: 654
+  - uid: 635
     components:
     - type: Transform
       pos: 0.5,12.5
       parent: 1
-  - uid: 655
+  - uid: 636
     components:
     - type: Transform
       pos: 1.5,13.5
       parent: 1
-  - uid: 656
+  - uid: 637
     components:
     - type: Transform
       pos: 1.5,12.5
       parent: 1
 - proto: TableCounterMetal
   entities:
-  - uid: 657
+  - uid: 638
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 0.5,-7.5
       parent: 1
-  - uid: 658
+  - uid: 639
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 0.5,-8.5
       parent: 1
-  - uid: 659
+  - uid: 640
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -0.5,-7.5
       parent: 1
-  - uid: 660
+  - uid: 641
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -0.5,-8.5
       parent: 1
-  - uid: 661
+  - uid: 642
     components:
     - type: Transform
       pos: -2.5,12.5
       parent: 1
-  - uid: 662
+  - uid: 643
     components:
     - type: Transform
       pos: -2.5,13.5
       parent: 1
 - proto: TableCounterWood
   entities:
-  - uid: 663
+  - uid: 644
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -2.5,-0.5
       parent: 1
-  - uid: 664
+  - uid: 645
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -1.5,-1.5
       parent: 1
-  - uid: 665
+  - uid: 646
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -1.5,-2.5
       parent: 1
-  - uid: 666
+  - uid: 647
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -1.5,-3.5
       parent: 1
-  - uid: 667
+  - uid: 648
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -5148,13 +5022,13 @@ entities:
       parent: 1
 - proto: TableGlass
   entities:
-  - uid: 668
+  - uid: 649
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -3.5,2.5
       parent: 1
-  - uid: 669
+  - uid: 650
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -5162,7 +5036,7 @@ entities:
       parent: 1
 - proto: TablePlasmaGlass
   entities:
-  - uid: 670
+  - uid: 651
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -5170,95 +5044,95 @@ entities:
       parent: 1
 - proto: Thruster
   entities:
-  - uid: 671
+  - uid: 652
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 3.5,-12.5
       parent: 1
-  - uid: 672
+  - uid: 653
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 4.5,-11.5
       parent: 1
-  - uid: 673
+  - uid: 654
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 5.5,-11.5
       parent: 1
-  - uid: 674
+  - uid: 655
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 5.5,-9.5
       parent: 1
-  - uid: 675
+  - uid: 656
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 5.5,-7.5
       parent: 1
-  - uid: 676
+  - uid: 657
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -4.5,-9.5
       parent: 1
-  - uid: 677
+  - uid: 658
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -4.5,-7.5
       parent: 1
-  - uid: 678
+  - uid: 659
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -4.5,-11.5
       parent: 1
-  - uid: 679
+  - uid: 660
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -3.5,-11.5
       parent: 1
-  - uid: 680
+  - uid: 661
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -2.5,-12.5
       parent: 1
-  - uid: 681
+  - uid: 662
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -4.5,11.5
       parent: 1
-  - uid: 682
+  - uid: 663
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -4.5,12.5
       parent: 1
-  - uid: 683
+  - uid: 664
     components:
     - type: Transform
       pos: -4.5,13.5
       parent: 1
-  - uid: 684
+  - uid: 665
     components:
     - type: Transform
       pos: 5.5,13.5
       parent: 1
-  - uid: 685
+  - uid: 666
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 5.5,12.5
       parent: 1
-  - uid: 686
+  - uid: 667
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -5266,253 +5140,253 @@ entities:
       parent: 1
 - proto: VendingMachineBooze
   entities:
-  - uid: 687
+  - uid: 668
     components:
     - type: Transform
       pos: -3.5,-0.5
       parent: 1
-  - uid: 688
+  - uid: 669
     components:
     - type: Transform
       pos: -2.5,-8.5
       parent: 1
-  - uid: 689
+  - uid: 670
     components:
     - type: Transform
       pos: -2.5,11.5
       parent: 1
 - proto: VendingMachineCoffee
   entities:
-  - uid: 690
+  - uid: 671
     components:
     - type: Transform
       pos: 0.5,-0.5
       parent: 1
 - proto: VendingMachineDiscount
   entities:
-  - uid: 691
+  - uid: 672
     components:
     - type: Transform
       pos: -0.5,-0.5
       parent: 1
 - proto: VendingMachineEngivend
   entities:
-  - uid: 692
+  - uid: 673
     components:
     - type: Transform
       pos: 3.5,-9.5
       parent: 1
 - proto: VendingMachineGames
   entities:
-  - uid: 693
+  - uid: 674
     components:
     - type: Transform
       pos: -2.5,14.5
       parent: 1
 - proto: VendingMachineMedical
   entities:
-  - uid: 694
+  - uid: 675
     components:
     - type: Transform
       pos: -3.5,1.5
       parent: 1
 - proto: VendingMachineSec
   entities:
-  - uid: 695
+  - uid: 676
     components:
     - type: Transform
       pos: 1.5,7.5
       parent: 1
 - proto: VendingMachineYouTool
   entities:
-  - uid: 696
+  - uid: 677
     components:
     - type: Transform
       pos: 3.5,-7.5
       parent: 1
 - proto: WallShuttle
   entities:
-  - uid: 697
+  - uid: 678
     components:
     - type: Transform
       pos: 5.5,0.5
       parent: 1
-  - uid: 698
+  - uid: 679
     components:
     - type: Transform
       pos: -4.5,0.5
       parent: 1
-  - uid: 699
+  - uid: 680
     components:
     - type: Transform
       pos: -4.5,1.5
       parent: 1
-  - uid: 700
+  - uid: 681
     components:
     - type: Transform
       pos: -4.5,-0.5
       parent: 1
-  - uid: 701
+  - uid: 682
     components:
     - type: Transform
       pos: -4.5,-1.5
       parent: 1
-  - uid: 702
+  - uid: 683
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: -4.5,-5.5
       parent: 1
-  - uid: 703
+  - uid: 684
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -3.5,-6.5
       parent: 1
-  - uid: 704
+  - uid: 685
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 4.5,-6.5
       parent: 1
-  - uid: 705
+  - uid: 686
     components:
     - type: Transform
       pos: 5.5,-5.5
       parent: 1
-  - uid: 706
+  - uid: 687
     components:
     - type: Transform
       pos: 5.5,-3.5
       parent: 1
-  - uid: 707
+  - uid: 688
     components:
     - type: Transform
       pos: 5.5,-1.5
       parent: 1
-  - uid: 708
+  - uid: 689
     components:
     - type: Transform
       pos: 5.5,2.5
       parent: 1
-  - uid: 709
+  - uid: 690
     components:
     - type: Transform
       pos: 5.5,4.5
       parent: 1
-  - uid: 710
+  - uid: 691
     components:
     - type: Transform
       pos: 5.5,6.5
       parent: 1
-  - uid: 711
+  - uid: 692
     components:
     - type: Transform
       pos: 5.5,9.5
       parent: 1
-  - uid: 712
+  - uid: 693
     components:
     - type: Transform
       pos: 4.5,10.5
       parent: 1
-  - uid: 713
+  - uid: 694
     components:
     - type: Transform
       pos: 4.5,14.5
       parent: 1
-  - uid: 714
+  - uid: 695
     components:
     - type: Transform
       pos: -3.5,14.5
       parent: 1
-  - uid: 715
+  - uid: 696
     components:
     - type: Transform
       pos: -3.5,10.5
       parent: 1
-  - uid: 716
+  - uid: 697
     components:
     - type: Transform
       pos: -4.5,5.5
       parent: 1
-  - uid: 717
+  - uid: 698
     components:
     - type: Transform
       pos: -4.5,6.5
       parent: 1
-  - uid: 718
+  - uid: 699
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 4.5,-9.5
       parent: 1
-  - uid: 719
+  - uid: 700
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 4.5,-10.5
       parent: 1
-  - uid: 720
+  - uid: 701
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 3.5,-10.5
       parent: 1
-  - uid: 721
+  - uid: 702
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 2.5,-10.5
       parent: 1
-  - uid: 722
+  - uid: 703
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 2.5,-11.5
       parent: 1
-  - uid: 723
+  - uid: 704
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -1.5,-11.5
       parent: 1
-  - uid: 724
+  - uid: 705
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -1.5,-10.5
       parent: 1
-  - uid: 725
+  - uid: 706
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -2.5,-10.5
       parent: 1
-  - uid: 726
+  - uid: 707
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -3.5,-10.5
       parent: 1
-  - uid: 727
+  - uid: 708
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -3.5,-9.5
       parent: 1
-  - uid: 728
+  - uid: 709
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -0.5,-13.5
       parent: 1
-  - uid: 729
+  - uid: 710
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 0.5,-13.5
       parent: 1
-  - uid: 730
+  - uid: 711
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -5520,59 +5394,59 @@ entities:
       parent: 1
 - proto: WallShuttleDiagonal
   entities:
-  - uid: 731
+  - uid: 712
     components:
     - type: Transform
       pos: -4.5,10.5
       parent: 1
-  - uid: 732
+  - uid: 713
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 5.5,10.5
       parent: 1
-  - uid: 733
+  - uid: 714
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 5.5,-6.5
       parent: 1
-  - uid: 734
+  - uid: 715
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -4.5,-6.5
       parent: 1
-  - uid: 735
+  - uid: 716
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 5.5,-10.5
       parent: 1
-  - uid: 736
+  - uid: 717
     components:
     - type: Transform
       pos: -4.5,-10.5
       parent: 1
-  - uid: 737
+  - uid: 718
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -2.5,-11.5
       parent: 1
-  - uid: 738
+  - uid: 719
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -1.5,-13.5
       parent: 1
-  - uid: 739
+  - uid: 720
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 2.5,-13.5
       parent: 1
-  - uid: 740
+  - uid: 721
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -5580,155 +5454,155 @@ entities:
       parent: 1
 - proto: WallShuttleInterior
   entities:
-  - uid: 741
+  - uid: 722
     components:
     - type: Transform
       pos: 0.5,0.5
       parent: 1
-  - uid: 742
+  - uid: 723
     components:
     - type: Transform
       pos: -3.5,0.5
       parent: 1
-  - uid: 743
+  - uid: 724
     components:
     - type: Transform
       pos: -2.5,0.5
       parent: 1
-  - uid: 744
+  - uid: 725
     components:
     - type: Transform
       pos: -1.5,0.5
       parent: 1
-  - uid: 745
+  - uid: 726
     components:
     - type: Transform
       pos: -0.5,0.5
       parent: 1
-  - uid: 746
+  - uid: 727
     components:
     - type: Transform
       pos: -1.5,-0.5
       parent: 1
-  - uid: 747
+  - uid: 728
     components:
     - type: Transform
       pos: -2.5,-6.5
       parent: 1
-  - uid: 748
+  - uid: 729
     components:
     - type: Transform
       pos: -1.5,-6.5
       parent: 1
-  - uid: 749
+  - uid: 730
     components:
     - type: Transform
       pos: -0.5,-6.5
       parent: 1
-  - uid: 750
+  - uid: 731
     components:
     - type: Transform
       pos: 0.5,-6.5
       parent: 1
-  - uid: 751
+  - uid: 732
     components:
     - type: Transform
       pos: 1.5,-6.5
       parent: 1
-  - uid: 752
+  - uid: 733
     components:
     - type: Transform
       pos: 3.5,-6.5
       parent: 1
-  - uid: 753
+  - uid: 734
     components:
     - type: Transform
       pos: -2.5,10.5
       parent: 1
-  - uid: 754
+  - uid: 735
     components:
     - type: Transform
       pos: -1.5,10.5
       parent: 1
-  - uid: 755
+  - uid: 736
     components:
     - type: Transform
       pos: -0.5,10.5
       parent: 1
-  - uid: 756
+  - uid: 737
     components:
     - type: Transform
       pos: 0.5,10.5
       parent: 1
-  - uid: 757
+  - uid: 738
     components:
     - type: Transform
       pos: 1.5,10.5
       parent: 1
-  - uid: 758
+  - uid: 739
     components:
     - type: Transform
       pos: 2.5,10.5
       parent: 1
-  - uid: 759
+  - uid: 740
     components:
     - type: Transform
       pos: -3.5,6.5
       parent: 1
-  - uid: 760
+  - uid: 741
     components:
     - type: Transform
       pos: -2.5,6.5
       parent: 1
-  - uid: 761
+  - uid: 742
     components:
     - type: Transform
       pos: -1.5,6.5
       parent: 1
-  - uid: 762
+  - uid: 743
     components:
     - type: Transform
       pos: 0.5,6.5
       parent: 1
-  - uid: 763
+  - uid: 744
     components:
     - type: Transform
       pos: 1.5,6.5
       parent: 1
-  - uid: 764
+  - uid: 745
     components:
     - type: Transform
       pos: 2.5,6.5
       parent: 1
-  - uid: 765
+  - uid: 746
     components:
     - type: Transform
       pos: 2.5,8.5
       parent: 1
 - proto: WallWeaponCapacitorRecharger
   entities:
-  - uid: 766
+  - uid: 747
     components:
     - type: Transform
       pos: 2.5,8.5
       parent: 1
 - proto: WaterCooler
   entities:
-  - uid: 767
+  - uid: 748
     components:
     - type: Transform
       pos: 3.5,15.5
       parent: 1
 - proto: WeaponCapacitorRecharger
   entities:
-  - uid: 768
+  - uid: 749
     components:
     - type: Transform
       pos: -0.5,13.5
       parent: 1
 - proto: WindoorBarLocked
   entities:
-  - uid: 769
+  - uid: 750
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -5736,7 +5610,7 @@ entities:
       parent: 1
 - proto: WindoorSecureChemistryLocked
   entities:
-  - uid: 770
+  - uid: 751
     components:
     - type: Transform
       rot: 3.141592653589793 rad
@@ -5744,7 +5618,7 @@ entities:
       parent: 1
 - proto: WindoorSecureMedicalLocked
   entities:
-  - uid: 771
+  - uid: 752
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
@@ -5752,61 +5626,61 @@ entities:
       parent: 1
 - proto: WindowFrostedDirectional
   entities:
-  - uid: 772
+  - uid: 753
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 2.5,-1.5
       parent: 1
-  - uid: 773
+  - uid: 754
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 2.5,-2.5
       parent: 1
-  - uid: 774
+  - uid: 755
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 2.5,-3.5
       parent: 1
-  - uid: 775
+  - uid: 756
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 2.5,-4.5
       parent: 1
-  - uid: 776
+  - uid: 757
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 3.5,-1.5
       parent: 1
-  - uid: 777
+  - uid: 758
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 3.5,-2.5
       parent: 1
-  - uid: 778
+  - uid: 759
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 3.5,-3.5
       parent: 1
-  - uid: 779
+  - uid: 760
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 3.5,-4.5
       parent: 1
-  - uid: 780
+  - uid: 761
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 2.5,16.5
       parent: 1
-  - uid: 781
+  - uid: 762
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
@@ -5814,291 +5688,45 @@ entities:
       parent: 1
 - proto: WindowReinforcedDirectional
   entities:
-  - uid: 782
+  - uid: 763
     components:
     - type: Transform
       pos: 0.5,-12.5
       parent: 1
-  - uid: 783
+  - uid: 764
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: 0.5,-12.5
       parent: 1
-  - uid: 784
+  - uid: 765
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: 0.5,-12.5
       parent: 1
-  - uid: 785
+  - uid: 766
     components:
     - type: Transform
       rot: -1.5707963267948966 rad
       pos: 0.5,-12.5
       parent: 1
-  - uid: 786
+  - uid: 767
     components:
     - type: Transform
       rot: 3.141592653589793 rad
       pos: -2.5,3.5
       parent: 1
-  - uid: 787
+  - uid: 768
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -2.5,4.5
       parent: 1
-  - uid: 788
+  - uid: 769
     components:
     - type: Transform
       rot: 1.5707963267948966 rad
       pos: -2.5,5.5
       parent: 1
-- proto: XmasLights
-  entities:
-  - uid: 789
-    components:
-    - type: Transform
-      pos: 2.5,5.5
-      parent: 1
-    - type: Physics
-      canCollide: False
-    - type: Fixtures
-      fixtures: {}
-  - uid: 790
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 4.5,4.5
-      parent: 1
-    - type: Physics
-      canCollide: False
-    - type: Fixtures
-      fixtures: {}
-  - uid: 791
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 4.5,-1.5
-      parent: 1
-    - type: Physics
-      canCollide: False
-    - type: Fixtures
-      fixtures: {}
-  - uid: 792
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 3.5,-5.5
-      parent: 1
-    - type: Physics
-      canCollide: False
-    - type: Fixtures
-      fixtures: {}
-  - uid: 793
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 4.5,-5.5
-      parent: 1
-    - type: Physics
-      canCollide: False
-    - type: Fixtures
-      fixtures: {}
-  - uid: 794
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: -0.5,-5.5
-      parent: 1
-    - type: Physics
-      canCollide: False
-    - type: Fixtures
-      fixtures: {}
-  - uid: 795
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 1.5,-5.5
-      parent: 1
-    - type: Physics
-      canCollide: False
-    - type: Fixtures
-      fixtures: {}
-  - uid: 796
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: -1.5,-5.5
-      parent: 1
-    - type: Physics
-      canCollide: False
-    - type: Fixtures
-      fixtures: {}
-  - uid: 797
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: -3.5,-5.5
-      parent: 1
-    - type: Physics
-      canCollide: False
-    - type: Fixtures
-      fixtures: {}
-  - uid: 798
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: -3.5,-5.5
-      parent: 1
-    - type: Physics
-      canCollide: False
-    - type: Fixtures
-      fixtures: {}
-  - uid: 799
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: -3.5,-1.5
-      parent: 1
-    - type: Physics
-      canCollide: False
-    - type: Fixtures
-      fixtures: {}
-  - uid: 800
-    components:
-    - type: Transform
-      pos: -2.5,-0.5
-      parent: 1
-    - type: Physics
-      canCollide: False
-    - type: Fixtures
-      fixtures: {}
-  - uid: 801
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: -2.5,1.5
-      parent: 1
-    - type: Physics
-      canCollide: False
-    - type: Fixtures
-      fixtures: {}
-  - uid: 802
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: -0.5,1.5
-      parent: 1
-    - type: Physics
-      canCollide: False
-    - type: Fixtures
-      fixtures: {}
-  - uid: 803
-    components:
-    - type: Transform
-      pos: -1.5,5.5
-      parent: 1
-    - type: Physics
-      canCollide: False
-    - type: Fixtures
-      fixtures: {}
-  - uid: 804
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: -3.5,5.5
-      parent: 1
-    - type: Physics
-      canCollide: False
-    - type: Fixtures
-      fixtures: {}
-  - uid: 805
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: -2.5,7.5
-      parent: 1
-    - type: Physics
-      canCollide: False
-    - type: Fixtures
-      fixtures: {}
-  - uid: 806
-    components:
-    - type: Transform
-      pos: -0.5,9.5
-      parent: 1
-    - type: Physics
-      canCollide: False
-    - type: Fixtures
-      fixtures: {}
-  - uid: 807
-    components:
-    - type: Transform
-      pos: 0.5,9.5
-      parent: 1
-    - type: Physics
-      canCollide: False
-    - type: Fixtures
-      fixtures: {}
-  - uid: 808
-    components:
-    - type: Transform
-      pos: 1.5,9.5
-      parent: 1
-    - type: Physics
-      canCollide: False
-    - type: Fixtures
-      fixtures: {}
-  - uid: 809
-    components:
-    - type: Transform
-      rot: -1.5707963267948966 rad
-      pos: 3.5,14.5
-      parent: 1
-    - type: Physics
-      canCollide: False
-    - type: Fixtures
-      fixtures: {}
-  - uid: 810
-    components:
-    - type: Transform
-      rot: 1.5707963267948966 rad
-      pos: -2.5,14.5
-      parent: 1
-    - type: Physics
-      canCollide: False
-    - type: Fixtures
-      fixtures: {}
-  - uid: 811
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: -0.5,11.5
-      parent: 1
-    - type: Physics
-      canCollide: False
-    - type: Fixtures
-      fixtures: {}
-  - uid: 812
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 0.5,11.5
-      parent: 1
-    - type: Physics
-      canCollide: False
-    - type: Fixtures
-      fixtures: {}
-  - uid: 813
-    components:
-    - type: Transform
-      rot: 3.141592653589793 rad
-      pos: 1.5,11.5
-      parent: 1
-    - type: Physics
-      canCollide: False
-    - type: Fixtures
-      fixtures: {}
 ...


### PR DESCRIPTION
<!-- Guidelines: https://docs.spacestation14.io/en/getting-started/pr-guideline -->

## About the PR
changed the shuttle to non Christmas version
and changed the rad collectors to the active rad collectors

## Why / Balance
<!-- Discuss how this would affect game balance or explain why it was changed. Link any relevant discussions or issues. -->

## Technical details
<!-- Summary of code changes for easier review. -->

## Media
<!-- Attach media if the PR makes ingame changes (clothing, items, features, etc). 
Small fixes/refactors are exempt. Media may be used in SS14 progress reports with credit. -->

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [x] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [x] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
<!-- Add a Changelog entry to make players aware of new features or changes that could affect gameplay.
Make sure to read the guidelines and take this Changelog template out of the comment block in order for it to show up.
Changelog must have a :cl: symbol, so the bot recognizes the changes and adds them to the game's changelog. -->
<!--
:cl:
- add: Added fun!
- remove: Removed fun!
- tweak: Changed fun!
- fix: Fixed fun!
-->
