### PR TITLE
Void Oil Nerf + Voidflower Error protection

### DIFF
--- a/Content.Shared/Fluids/SharedPuddleSystem.Evaporation.cs
+++ b/Content.Shared/Fluids/SharedPuddleSystem.Evaporation.cs
@@ -8,7 +8,7 @@ public abstract partial class SharedPuddleSystem
     [ValidatePrototypeId<ReagentPrototype>]
     private const string Water = "Water";
 
-    public static readonly string[] EvaporationReagents = [Water];
+    public static readonly string[] EvaporationReagents = [Water, "Voidoil"];
 
     public bool CanFullyEvaporate(Solution solution)
     {

--- a/Resources/Prototypes/Entities/Objects/Consumable/Food/produce.yml
+++ b/Resources/Prototypes/Entities/Objects/Consumable/Food/produce.yml
@@ -2948,6 +2948,7 @@
     solutions:
       food:
         maxVol: 25
+        canReact: false #reduces chance of errors if mutated chemicals are added, as void oil can't convert them on harvest.
         reagents:
         - ReagentId: Voidoil #void oil ate everything else
           Quantity: 25

--- a/Resources/Prototypes/Reagents/toxins.yml
+++ b/Resources/Prototypes/Reagents/toxins.yml
@@ -713,8 +713,8 @@
   color: "#58031e"
   worksOnTheDead: true #also means you can't build it up in dead people.
   metabolisms:
-    Poison: #make chemical convert all other chemicals into it
-      metabolismRate: 0.5
+    Poison:
+      metabolismRate: 0.25
       effects:
         - !type:PopupMessage
           type: Local
@@ -722,11 +722,11 @@
           messages: [ "generic-reagent-effect-consuming-insides"]
           probability: 0.33
         - !type:SatiateHunger
-          factor: -3
+          factor: -2
         - !type:SatiateThirst
-          factor: -3
+          factor: -2
         - !type:ModifyBloodLevel #bleeding also leaks chemical, which transforms blood into more void oil.
-          amount: -5
+          amount: -2
         - !type:GenericStatusEffect
           key: Glowing
           time: 300


### PR DESCRIPTION
## About the PR
Void Oil removes less blood and now evaporates, although also metabolises slower. 

Voidflower's food fluid container is now non-reactive to ward against additional chemicals mutating or crossbreeding into them and causing (admittedly harmless) errors due to no reaction effects occurring on harvest. This has no effect on their other functions. as eating or grinding them would then cause the reaction.

## Why / Balance
Void Oil when absorbed via a Diona's feet would trap them in an infinite bleeding cycle, as they would bleed blood and void oil, which they would then re-absorbed. Void oil can also become obnoxious to clean, especially footsteps. Allowing it to evaporate solves both these issues, as diona don't seem to absorb evaporating chemicals and janitors don't need to clean it if it cleans itself.

Void Oil's blood removal was quite high, considering how you can make an infinite amount of it once you get any starting amount, so it's been reduced a bit. It also metabolises slower. With 30u injected, you'll go down to about 65% blood level after a minute or two. Void Oil's main threat comes from it effectively preventing the use of other chemicals for its duration.

## Technical details
YAML Changes
Added "Voidoil" to EvaporationReagents in SharedPuddleSystem class.

## Media

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
<!-- List any breaking changes, including namespaces, public class/method/field changes, prototype renames; and provide instructions for fixing them.
This will be posted in #codebase-changes. -->

**Changelog**
:cl:
- tweak: Void Oil Threat Nerf.
- tweak: Voidflowers are Nonreactive.
-->
