### PR TITLE
Salvage Bugfixes and Goliath Rebalancing

### DIFF
--- a/Content.Shared/Weapons/Marker/LeechOnMarkerComponent.cs
+++ b/Content.Shared/Weapons/Marker/LeechOnMarkerComponent.cs
@@ -1,5 +1,6 @@
 using Content.Shared.Damage;
 using Robust.Shared.GameStates;
+using Content.Shared.EntityEffects;
 
 namespace Content.Shared.Weapons.Marker;
 
@@ -10,7 +11,10 @@ namespace Content.Shared.Weapons.Marker;
 public sealed partial class LeechOnMarkerComponent : Component
 {
     // TODO: Can't network damagespecifiers yet last I checked.
-    [ViewVariables(VVAccess.ReadWrite)]
-    [DataField("leech", required: true)]
-    public DamageSpecifier Leech = new();
+    //[ViewVariables(VVAccess.ReadWrite)]
+    [DataField("leechEffects", required: true, serverOnly: true)]
+    public List<EntityEffect> Effects = new(0);
+
+    [DataField("targetSelf")]
+    public bool TargetSelf = true;
 }

--- a/Content.Shared/Weapons/Marker/LeechOnMarkerComponent.cs
+++ b/Content.Shared/Weapons/Marker/LeechOnMarkerComponent.cs
@@ -12,9 +12,9 @@ public sealed partial class LeechOnMarkerComponent : Component
 {
     // TODO: Can't network damagespecifiers yet last I checked.
     //[ViewVariables(VVAccess.ReadWrite)]
-    [DataField("leechEffects", required: true, serverOnly: true)]
-    public List<EntityEffect> Effects = new(0);
+    [DataField("userEffects", serverOnly: true)]
+    public List<EntityEffect> UserEffects = new(0);
 
-    [DataField("targetSelf")]
-    public bool TargetSelf = true;
+    [DataField("targetEffects", serverOnly: true)]
+    public List<EntityEffect> TargetEffects = new(0);
 }

--- a/Content.Shared/Weapons/Marker/SharedDamageMarkerSystem.cs
+++ b/Content.Shared/Weapons/Marker/SharedDamageMarkerSystem.cs
@@ -1,3 +1,4 @@
+using Content.Shared.EntityEffects;
 using Content.Shared.Damage;
 using Content.Shared.Projectiles;
 using Content.Shared.Weapons.Melee.Events;
@@ -7,6 +8,8 @@ using Robust.Shared.Audio.Systems;
 using Robust.Shared.Network;
 using Robust.Shared.Physics.Events;
 using Robust.Shared.Timing;
+using System.Xml;
+
 
 namespace Content.Shared.Weapons.Marker;
 
@@ -15,7 +18,7 @@ public abstract class SharedDamageMarkerSystem : EntitySystem
     [Dependency] private readonly IGameTiming _timing = default!;
     [Dependency] private readonly INetManager _netManager = default!;
     [Dependency] private readonly SharedAudioSystem _audio = default!;
-    [Dependency] private readonly DamageableSystem _damageable = default!;
+    //[Dependency] private readonly DamageableSystem _damageable = default!;
     [Dependency] private readonly EntityWhitelistSystem _whitelistSystem = default!;
 
     public override void Initialize()
@@ -36,7 +39,20 @@ public abstract class SharedDamageMarkerSystem : EntitySystem
 
         if (TryComp<LeechOnMarkerComponent>(args.Used, out var leech))
         {
-            _damageable.TryChangeDamage(args.User, leech.Leech, true, false, origin: args.Used, splitLimbDamage: false);
+            //_damageable.TryChangeDamage(args.User, leech.Leech, true, false, origin: args.Used, splitLimbDamage: false);
+
+            EntityUid target = args.User;
+            if (leech.TargetSelf == false)
+                target = uid;
+
+            Log.Debug(target.Id.ToString());
+            var effargs = new EntityEffectBaseArgs(target, EntityManager);
+            Log.Debug(leech.Effects.Count.ToString());
+            foreach (var effect in leech.Effects)
+            {
+                Log.Debug("Bonk");
+                effect.Effect(effargs);
+            }
         }
     }
 

--- a/Content.Shared/Weapons/Marker/SharedDamageMarkerSystem.cs
+++ b/Content.Shared/Weapons/Marker/SharedDamageMarkerSystem.cs
@@ -39,20 +39,13 @@ public abstract class SharedDamageMarkerSystem : EntitySystem
 
         if (TryComp<LeechOnMarkerComponent>(args.Used, out var leech))
         {
-            //_damageable.TryChangeDamage(args.User, leech.Leech, true, false, origin: args.Used, splitLimbDamage: false);
+            var userargs = new EntityEffectBaseArgs(args.User, EntityManager); //apply effects to the user
+            foreach (var effect in leech.UserEffects)
+                effect.Effect(userargs);
 
-            EntityUid target = args.User;
-            if (leech.TargetSelf == false)
-                target = uid;
-
-            Log.Debug(target.Id.ToString());
-            var effargs = new EntityEffectBaseArgs(target, EntityManager);
-            Log.Debug(leech.Effects.Count.ToString());
-            foreach (var effect in leech.Effects)
-            {
-                Log.Debug("Bonk");
-                effect.Effect(effargs);
-            }
+            var targetargs = new EntityEffectBaseArgs(uid, EntityManager); //apply effects to the target
+            foreach (var effect in leech.TargetEffects)
+                effect.Effect(targetargs);
         }
     }
 

--- a/Content.Shared/Weapons/Marker/SharedDamageMarkerSystem.cs
+++ b/Content.Shared/Weapons/Marker/SharedDamageMarkerSystem.cs
@@ -36,7 +36,7 @@ public abstract class SharedDamageMarkerSystem : EntitySystem
 
         if (TryComp<LeechOnMarkerComponent>(args.Used, out var leech))
         {
-            _damageable.TryChangeDamage(args.User, leech.Leech, true, false, origin: args.Used);
+            _damageable.TryChangeDamage(args.User, leech.Leech, true, false, origin: args.Used, splitLimbDamage: false);
         }
     }
 

--- a/Resources/Prototypes/Entities/Mobs/NPCs/asteroid.yml
+++ b/Resources/Prototypes/Entities/Mobs/NPCs/asteroid.yml
@@ -34,7 +34,7 @@
 
 - type: entity
   id: MobGoliath
-  parent: [ BaseMobAsteroid, MobBloodstream ]
+  parent: [ BaseMobAsteroid, SimpleSpaceMobBase ]
   name: goliath
   description: A massive beast that uses long tentacles to ensnare its prey, threatening them is not advised under any conditions.
   components:
@@ -56,6 +56,9 @@
     thresholds:
       0: Alive
       250: Dead
+  - type: SlowOnDamage
+    speedModifierThresholds:
+      200: 0.75
   - type: MeleeWeapon
     soundHit:
       path: "/Audio/Weapons/smash.ogg"

--- a/Resources/Prototypes/Entities/Mobs/NPCs/asteroid.yml
+++ b/Resources/Prototypes/Entities/Mobs/NPCs/asteroid.yml
@@ -4,6 +4,7 @@
   - BaseMob
   - MobAtmosExposed
   - MobCombat
+  - MobDamageableBody
   abstract: true
   components:
   - type: Reactive
@@ -33,7 +34,7 @@
 
 - type: entity
   id: MobGoliath
-  parent: BaseMobAsteroid
+  parent: [ BaseMobAsteroid, MobBloodstream ]
   name: goliath
   description: A massive beast that uses long tentacles to ensnare its prey, threatening them is not advised under any conditions.
   components:
@@ -159,7 +160,7 @@
     sprite: Mobs/Aliens/Asteroid/goliath.rsi
   - type: InteractionOutline
   - type: TimedDespawn
-    lifetime: 0.7
+    lifetime: 1
 
 - type: entity
   id: EffectGoliathTentacleSpawn
@@ -239,6 +240,7 @@
   - type: Butcherable
     spawned:
     - id: FoodHivelordRemains
+  - type: NoSlip
 
 - type: entity
   id: MobHivelordBrood
@@ -290,6 +292,7 @@
         15
   - type: TimedDespawn
     lifetime: 100
+  - type: NoSlip
 
 - type: entity
   id: FoodHivelordRemains

--- a/Resources/Prototypes/Entities/Objects/Weapons/Melee/mining.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Melee/mining.yml
@@ -124,11 +124,15 @@
   - type: UseDelay
     delay: 0.9
   - type: LeechOnMarker
-    leechEffects:
+    userEffects:
     - !type:HealthChange
       damage:
         groups:
           Brute: -10
+    targetEffects:
+    - !type:HealthChange
+      damage:
+        Blunt: 10
   - type: Gun
     soundGunshot: /Audio/Weapons/plasma_cutter.ogg
     fireRate: 1
@@ -212,11 +216,15 @@
   - type: UseDelay
     delay: 1.9
   - type: LeechOnMarker
-    leechEffects:
+    userEffects:
       - !type:HealthChange
         damage:
           groups:
             Brute: -21
+    targetEffects:
+    - !type:HealthChange
+      damage:
+        Blunt: 10
   - type: MeleeWeapon
   - type: Tag
     tags:

--- a/Resources/Prototypes/Entities/Objects/Weapons/Melee/mining.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Melee/mining.yml
@@ -124,9 +124,11 @@
   - type: UseDelay
     delay: 0.9
   - type: LeechOnMarker
-    leech:
-      groups:
-        Brute: -10
+    leechEffects:
+    - !type:HealthChange
+      damage:
+        groups:
+          Brute: -10
   - type: Gun
     soundGunshot: /Audio/Weapons/plasma_cutter.ogg
     fireRate: 1
@@ -210,9 +212,11 @@
   - type: UseDelay
     delay: 1.9
   - type: LeechOnMarker
-    leech:
-      groups:
-        Brute: -21
+    leechEffects:
+      - !type:HealthChange
+        damage:
+          groups:
+            Brute: -21
   - type: MeleeWeapon
   - type: Tag
     tags:

--- a/Resources/Prototypes/Entities/Objects/Weapons/Melee/mining.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Melee/mining.yml
@@ -129,10 +129,6 @@
       damage:
         groups:
           Brute: -10
-    targetEffects:
-    - !type:HealthChange
-      damage:
-        Blunt: 10
   - type: Gun
     soundGunshot: /Audio/Weapons/plasma_cutter.ogg
     fireRate: 1
@@ -221,10 +217,6 @@
         damage:
           groups:
             Brute: -21
-    targetEffects:
-    - !type:HealthChange
-      damage:
-        Blunt: 10
   - type: MeleeWeapon
   - type: Tag
     tags:


### PR DESCRIPTION
## About the PR
Crusher and Crusher Glaive now heal you properly. Previously they would split healing across all bodyparts even if they weren't damaged. 

Goliaths are no longer immortal, due to lacking the ability to be damaged. They can also bleed now. However as penance you can't butcher them alive anymore. I also ever so slightly toned down the speed of their tentacle attacks stunning you, by about a third of a second.

## Why / Balance
Bug bad, no bug good.

## Technical details
The crusher LeechOnMarker has been changed to use EntityEffects rather than direct damage specifiers. Crushers use a HealthChange EntityEffect targeting the user to heal what they previously did, split across damaged body parts only.

Additional functionality was added to allow EntityEffects to also target the hit target, so this could be a way to do something fun like set them on fire, or make them weh.

For Goliaths, they used their own custom mob prototype which seemingly lacked key features like "being able to be damaged". So i added those to bring them more in line with other mobs.

Salvage weapons such as PKAs and Crushers still struggle to deal killing blows to many enemies. From testing i've found this seems to be due to their innate structural damage, when removing that, they kill as usual. 

## Media
Many animals were harmed in the making of this PR. I forgot to take a picture of it though, just imagine a room of goliath and carp corpses.

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
None, Probably

**Changelog**

:cl:
- fix: Crushers and Crusher Glaives now heal their full amount again.
- fix: Goliaths are no longer immortal, but you also can't butcher them alive.
- tweak: Goliaths can bleed, and their tentacles stun slightly slower.

