### PR TITLE
Minor SliceableFood Bugfix and other plant changes

### DIFF
--- a/Content.Server/Nutrition/EntitySystems/SliceableFoodSystem.cs
+++ b/Content.Server/Nutrition/EntitySystems/SliceableFoodSystem.cs
@@ -47,9 +47,10 @@ public sealed class SliceableFoodSystem : EntitySystem
 
         if (!TryComp<UtensilComponent>(args.Used, out var utensil) || (utensil.Types & UtensilType.Knife) == 0) //if used item isn't a knife untensil, deny.
         {
-            if (entity.Comp.AnySharp == true && !HasComp<SharpComponent>(args.Used)) //alternatively, if any sharp item is allowed and doesn't have a sharpcomponent, deny.
+            if (entity.Comp.AnySharp == false || entity.Comp.AnySharp == true && !HasComp<SharpComponent>(args.Used)) //alternatively, if any sharp item is allowed and doesn't have a sharpcomponent, deny.
                 return;
         }
+
         var doAfterArgs = new DoAfterArgs(EntityManager,
             args.User,
             entity.Comp.SliceTime,

--- a/Resources/Prototypes/Entities/Objects/Consumable/Food/produce.yml
+++ b/Resources/Prototypes/Entities/Objects/Consumable/Food/produce.yml
@@ -142,6 +142,7 @@
     transferReagents: false
     potencyEffectsCount: true
     anySharp: true
+    sliceTime: 0.5f
 
 - type: entity
   parent: FoodProduceBase
@@ -201,6 +202,7 @@
     transferReagents: false
     potencyEffectsCount: true
     anySharp: true
+    sliceTime: 0.5f
 
 - type: entity
   name: steel-cap log
@@ -225,6 +227,7 @@
     transferReagents: false
     potencyEffectsCount: true
     anySharp: true
+    sliceTime: 0.5f
 
 - type: entity
   name: plasteel-cap log
@@ -247,6 +250,7 @@
     transferReagents: false
     potencyEffectsCount: true
     anySharp: true
+    sliceTime: 0.5f
 
 - type: entity
   name: nettle
@@ -1707,6 +1711,8 @@
     count: 100
     transferReagents: false
     potencyEffectsCount: true
+    anySharp: true
+    sliceTime: 0.5f
   - type: Produce
     seedId: spesoe
   - type: Tag
@@ -2847,6 +2853,7 @@
     potencyEffectsCount: true
     transferReagents: false
     anySharp: true
+    sliceTime: 0.5f
   - type: Produce
     seedId: cotton
   - type: Tag
@@ -2881,6 +2888,7 @@
     potencyEffectsCount: true
     transferReagents: false
     anySharp: true
+    sliceTime: 0.5f
   - type: Produce
     seedId: pyrotton
   - type: Tag
@@ -3074,14 +3082,14 @@
   - type: PointLight
     radius: 6.0
     color: "#fffb00"
-  - type: Perishable    # lots of point lights are laggy, so rot after 15 minutes to reduce that.
-    rotAfter: 900
+  - type: Perishable    # lots of point lights are laggy, so rot after 10 minutes to reduce that.
+    rotAfter: 600
     molsPerSecondPerUnitMass: 0
     forceRotProgression: true
   - type: RotInto
     entity: LampflowerCoreRot
     # once it would say bloated, turn into the rotten prototype
-    stage: 1
+    stage: 0
   - type: Tag
     tags:
     - Flower
@@ -3113,7 +3121,7 @@
 
 - type: entity
   name: voidflower
-  description: A bulky flower with core of darkness.
+  description: A bulky flower with a core of darkness.
   id: ProduceVoidflower
   parent: FoodProduceBase
   components:

--- a/Resources/Prototypes/Hydroponics/seeds.yml
+++ b/Resources/Prototypes/Hydroponics/seeds.yml
@@ -2252,9 +2252,9 @@
   yield: 2
   potency: 20
   harvestRepeat: Repeat
-  idealHeat: 3 #can survive the cold vacuum of space, it's got cryoxadone after all
-  heatTolerance: 300
-  lowPressureTolerance: 100
+  idealHeat: 0 #can survive the cold vacuum of space, it's got cryoxadone after all
+  heatTolerance: 298
+  lowPressureTolerance: 0
   chemicals:
     Fresium:
       Min: 1


### PR DESCRIPTION
## About the PR
Fixed bug in Sliceablefood that let you cut with anything if anysharp wasn't set. 
Cryoconuts can now survive in space, as they were supposed to.
Spesoes can now be cut with any sharp object to bring it into consistency with other choppables.
Slicable non-food Produce can be sliced in 0.5 seconds rather than 1 second because you need to slice a lot of it.
Lampflowers rot in 10 minutes rather than 15 as rotting timers are weird.

## Why / Balance
Pedantry.

## Technical details
93.75% YAML. 6.25% C#
For the AnySharp Bug, AnySharp defaults to false. If a test met the first knife utensil if statement and was true it'd move on to the second if statement where, as AnySharp was false, it would test false and not return as it should have.

This meant that return could only be met if anysharp was true and the testing item wasn't sharp, if it was false it let anything through.

The new if statement returns everything if anysharp is false, because the first test for the knife utensil was already failed, therefore the results of the second test don't matter. Anysharp being true meanwhile can test for a present sharp component.

## Media
N/A

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
<!-- You should understand that not following the above may get your PR closed at maintainer’s discretion -->

## Breaking changes
None, Probably

**Changelog**
:cl:
- tweak: Cryoconuts can survive in space
- tweak: Spesoes can be cut by anything sharp
- tweak: Lampflowers rot faster
- tweak: Non-Food produce can be cut faster
- fix: Non-Food Produce can't be cut with any item

