### PR TITLE
Tiny Botany Fixes

### DIFF
--- a/Content.Server/Botany/Systems/PlantAnalyzerSystem.cs
+++ b/Content.Server/Botany/Systems/PlantAnalyzerSystem.cs
@@ -170,11 +170,16 @@ public sealed class PlantAnalyzerSystem : BaseAnalyzerSystem<PlantAnalyzerCompon
             ("endurance", data.PlantData?.Endurance.ToString(PlantAnalyzerLocalizationHelper.DP) ?? missingData),
             ("lifespan", data.PlantData?.Lifespan.ToString(PlantAnalyzerLocalizationHelper.DP) ?? missingData),
             ("seeds", data.ProduceData is not null ? PlantAnalyzerLocalizationHelper.BooleanToLocalizedStrings(data.ProduceData.Seedless ? true : false, _prototypeManager) : missingData),
-            ("viable", data.PlantData is not null ? PlantAnalyzerLocalizationHelper.BooleanToLocalizedStrings(data.PlantData.Viable ? true : false, _prototypeManager) : missingData),
-            ("kudzu", data.PlantData is not null ? PlantAnalyzerLocalizationHelper.BooleanToLocalizedStrings(data.PlantData.Kudzu ? true : false, _prototypeManager) : missingData),
+            ("viable", data.PlantData?.Viable.ToString() ?? missingData),
+            ("kudzu", data.PlantData?.Kudzu.ToString() ?? missingData),
             ("indent", "    "),
             ("nl", "\n")
         ];
+
+        var test = data.PlantData?.Kudzu.ToString() ?? "nope";
+        Log.Debug(test);
+        test = data.PlantData?.Viable.ToString() ?? "nope";
+        Log.Debug(test);
 
         _paperSystem.SetContent((printed, paperComp), Loc.GetString($"plant-analyzer-printout", [.. parameters]));
         _labelSystem.Label(printed, seedName);

--- a/Content.Server/Botany/Systems/PlantAnalyzerSystem.cs
+++ b/Content.Server/Botany/Systems/PlantAnalyzerSystem.cs
@@ -176,11 +176,6 @@ public sealed class PlantAnalyzerSystem : BaseAnalyzerSystem<PlantAnalyzerCompon
             ("nl", "\n")
         ];
 
-        var test = data.PlantData?.Kudzu.ToString() ?? "nope";
-        Log.Debug(test);
-        test = data.PlantData?.Viable.ToString() ?? "nope";
-        Log.Debug(test);
-
         _paperSystem.SetContent((printed, paperComp), Loc.GetString($"plant-analyzer-printout", [.. parameters]));
         _labelSystem.Label(printed, seedName);
         _audioSystem.PlayPvs(component.SoundPrint, uid, AudioParams.Default);

--- a/Content.Shared/Botany/PlantAnalyzer/PlantAnalyzerScannedUserMessage.cs
+++ b/Content.Shared/Botany/PlantAnalyzer/PlantAnalyzerScannedUserMessage.cs
@@ -99,7 +99,7 @@ public sealed class PlantAnalyzerProduceData(int yield, float potency, List<stri
             potencyFtl += "gigantic";
         else if (potency < 80)
             potencyFtl += "ludicrous";
-        else if (potency < 99)
+        else if (potency < 100)
             potencyFtl += "immeasurable";
         else
             potencyFtl += "perfect"; //you've earned this, king.

--- a/Resources/Locale/en-US/botany/components/plant-analyzer-component.ftl
+++ b/Resources/Locale/en-US/botany/components/plant-analyzer-component.ftl
@@ -78,13 +78,13 @@ plant-analyzer-printout = [color=#9FED58][head=2]Plant Analyzer Report[/head][/c
     }──────────────────────────────{$nl
     }[bullet/] Species: {$seedName}{$nl
     }{$indent}[bullet/] Viable: {$viable ->
-        [no][color=red]No[/color]
-        [yes][color=green]Yes[/color]
+        [False][color=red]No[/color]
+        [True][color=green]Yes[/color]
         *[other]{LOC("plant-analyzer-printout-missing")}
     }{$nl
     }{$indent}[bullet/] Kudzu: {$kudzu ->
-    [no][color=green]No[/color]
-    [yes][color=red]Yes[/color]
+    [False][color=green]No[/color]
+    [True][color=red]Yes[/color]
     *[other]{LOC("plant-analyzer-printout-missing")}
     }{$nl
     }{$indent}[bullet/] Endurance: {$endurance}{$nl

--- a/Resources/Prototypes/Entities/Clothing/Belt/belts.yml
+++ b/Resources/Prototypes/Entities/Clothing/Belt/belts.yml
@@ -342,7 +342,6 @@
     whitelist:
       tags:
         - PlantAnalyzer
-        - PlantSampleTaker
         - BotanyShovel
         - BotanyHoe
         - BotanyHatchet
@@ -352,10 +351,13 @@
         - Syringe
         - CigPack
         - Dropper
+        - Swab
+        - SwabApplicator
       components:
         - Seed
         - Smokable
         - HandLabeler
+        - BotanySwab
   - type: ItemMapper
     mapLayers:
       hatchet:

--- a/Resources/Prototypes/Entities/Objects/Specific/Medical/disease.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/Medical/disease.yml
@@ -75,6 +75,10 @@
     swabDelay: 0.75
     usable: false
     contaminate: false
+  - type: Tag
+    tags:
+    - SwabApplicator
+
 
 - type: entity
   parent: BaseAmmoProvider # this is for cycling swabs out and not spawning 30 entities, trust

--- a/Resources/Prototypes/Entities/Objects/Specific/chemistry-vials.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/chemistry-vials.yml
@@ -205,7 +205,7 @@
         maxVol: 10
         reagents:
           - ReagentId: Chlorine
-            Quantity: 5
+            Quantity: 10
 
 - type: entity
   id: PlasmaChemistryVial

--- a/Resources/Prototypes/tags.yml
+++ b/Resources/Prototypes/tags.yml
@@ -1381,6 +1381,9 @@
   id: Swab
 
 - type: Tag
+  id: SwabApplicator
+
+- type: Tag
   id: Syndicate
 
 - type: Tag


### PR DESCRIPTION
Tiny fixes for plant related stuff

## About the PR
Plant Analyser printout viability and kudzu were always N/A, now they show properly. Fix may be of questionable code quality.
Plant Analysers could show "Perfect" at 99 potency as well as 100.
Swab Applicators couldn't be put in botany belts, now they can alongside regular swabs because why not.
Botany chemical box had only 5u of chlorine rather than 10u.

## Why / Balance
Procrastinating on Telescience

## Technical details
N/A

## Media
N/A

## Requirements
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.

## Breaking changes
Probably none

**Changelog**
:cl:
- tweak: Swab Applicators can now be put in plant belts.
- fix: Plant Analyser printouts now show viability and kudzu properly.
