### PR TITLE
Salvage Rework #1: Balance

### DIFF
--- a/Resources/Prototypes/Catalog/Fills/Lockers/cargo.yml
+++ b/Resources/Prototypes/Catalog/Fills/Lockers/cargo.yml
@@ -7,10 +7,11 @@
     - id: ClothingMaskGasExplorer
 
 - type: entityTable
-  id: LockerFillSalvageSpecialist
+  id: LockerFillSalvageSpecialist #mira change, add mineral scanner,
   table: !type:AllSelector
     children:
     - id: ClothingBeltUtilityFilled
+    - id: MineralScanner
     - id: SurvivalKnife
     - id: HandheldGPSBasic
     - id: RadioHandheld

--- a/Resources/Prototypes/Entities/Clothing/Back/mod_suit.yml
+++ b/Resources/Prototypes/Entities/Clothing/Back/mod_suit.yml
@@ -229,6 +229,7 @@
       - ModSuitModuleJetpackNormal
       - ModSuitModuleStorageNormal
       - ModSuitModuleFlashlight
+      - ModSuitModuleMagboots
 
 - type: entity
   id: ClothingBackpackModSuitAtmospheric

--- a/Resources/Prototypes/Entities/Markers/Spawners/Random/Salvage/spawners.yml
+++ b/Resources/Prototypes/Entities/Markers/Spawners/Random/Salvage/spawners.yml
@@ -502,6 +502,8 @@
         weight: 0.25
       - id: ClosetMaintenanceFilledRandom
         weight: 2
+      - id: SalvageMaterialCrateSpawner
+        weight: 0.5
       - !type:GroupSelector
         children:
         - id: Thruster

--- a/Resources/Prototypes/Entities/Mobs/NPCs/asteroid.yml
+++ b/Resources/Prototypes/Entities/Mobs/NPCs/asteroid.yml
@@ -5,6 +5,8 @@
   - MobAtmosExposed
   - MobCombat
   - MobDamageableBody
+  - BaseSimpleMobBody
+  - BaseSimpleMob
   abstract: true
   components:
   - type: Reactive
@@ -57,7 +59,7 @@
   - type: MobThresholds
     thresholds:
       0: Alive
-      150: Dead
+      200: Dead
   - type: MeleeWeapon
     soundHit:
       path: "/Audio/Weapons/smash.ogg"
@@ -214,7 +216,7 @@
   - type: MobThresholds
     thresholds:
       0: Alive
-      75: Dead
+      60: Dead
   - type: MeleeWeapon
     damage:
       types:
@@ -303,7 +305,7 @@
       NavSmash: !type:Bool
         true
   - type: TimedDespawn
-    lifetime: 100
+    lifetime: 30
   - type: NoSlip
 
 - type: entity
@@ -380,7 +382,7 @@
   - type: MobThresholds
     thresholds:
       0: Alive
-      45: Dead
+      60: Dead
   - type: MeleeWeapon
     angle: 0
     animation: WeaponArcBite

--- a/Resources/Prototypes/Entities/Mobs/NPCs/carp.yml
+++ b/Resources/Prototypes/Entities/Mobs/NPCs/carp.yml
@@ -159,7 +159,7 @@
     - type: MobThresholds
       thresholds:
         0: Alive
-        30: Dead
+        40: Dead #mira change
 
 - type: entity
   name: space carp
@@ -226,7 +226,7 @@
     - type: MobThresholds
       thresholds:
         0: Alive
-        82: Dead # Might seem random, but this brings up the hits to kill with a crusher mark to 3
+        85: Dead # Might seem random, but this brings up the hits to kill with a crusher mark to 3
     - type: Stamina
       critThreshold: 150
     - type: DamageStateVisuals

--- a/Resources/Prototypes/Entities/Mobs/NPCs/space.yml
+++ b/Resources/Prototypes/Entities/Mobs/NPCs/space.yml
@@ -34,7 +34,7 @@
   - type: MobThresholds
     thresholds:
       0: Alive
-      80: Dead
+      80: Dead #mira change
   - type: Stamina
     critThreshold: 150
   - type: MovementAlwaysTouching
@@ -171,7 +171,7 @@
   - type: MobThresholds
     thresholds:
       0: Alive
-      60: Dead
+      80: Dead #mira change
 
 - type: entity
   id: MobKangarooSpaceSalvage
@@ -198,7 +198,7 @@
   - type: MobThresholds
     thresholds:
       0: Alive
-      45: Dead
+      60: Dead #mira change
   - type: Stamina
     critThreshold: 150
   - type: DamageStateVisuals
@@ -299,7 +299,7 @@
     - type: MobThresholds
       thresholds:
         0: Alive
-        45: Dead
+        60: Dead #mira change
     - type: Stamina
       critThreshold: 150
     - type: DamageStateVisuals

--- a/Resources/Prototypes/Entities/Mobs/NPCs/spacetick.yml
+++ b/Resources/Prototypes/Entities/Mobs/NPCs/spacetick.yml
@@ -41,7 +41,7 @@
   - type: MobThresholds
     thresholds:
       0: Alive
-      5: Dead
+      10: Dead
   - type: Destructible
     thresholds:
     - trigger:

--- a/Resources/Prototypes/Entities/Objects/Specific/Robotics/ModSuits/Modules/storage.yml
+++ b/Resources/Prototypes/Entities/Objects/Specific/Robotics/ModSuits/Modules/storage.yml
@@ -26,7 +26,7 @@
     sprite: Objects/Specific/Robotics/ModSuits/Modules/storage.rsi
     state: storage
   - type: Storage
-    maxItemSize: Normal
+    maxItemSize: Huge
     grid:
     - 0,0,4,3
 
@@ -40,7 +40,7 @@
     sprite: Objects/Specific/Robotics/ModSuits/Modules/storage.rsi
     state: large
   - type: Storage
-    maxItemSize: Large
+    maxItemSize: Huge
     grid:
     - 0,0,6,3
 

--- a/Resources/Prototypes/Entities/Objects/Tools/pka_upgrade.yml
+++ b/Resources/Prototypes/Entities/Objects/Tools/pka_upgrade.yml
@@ -36,8 +36,8 @@
   - type: GunUpgradeDamage
     damage:
       types:
-        Blunt: 10
-        Structural: 15
+        Blunt: 7.5
+        Structural: 10
 
 - type: entity
   id: PKAUpgradeRange

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Projectiles/projectiles.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Projectiles/projectiles.yml
@@ -478,7 +478,6 @@
   id: BulletKinetic
   name: kinetic bolt
   parent: BaseBullet
-  categories: [ HideSpawnMenu ]
   description: Not too bad, but you still don't want to get hit by it.
   components:
   - type: Reflective
@@ -494,11 +493,11 @@
     impactEffect: BulletImpactEffectKinetic
     damage:
       types:
-        Blunt: 15
+        Blunt: 20
         Structural: 30
   # Short lifespan
-  - type: TimedDespawn
-    lifetime: 0.22 # roughly 5.5 tiles
+#  - type: TimedDespawn
+#    lifetime: 0.22 # roughly 5.5 tiles
   - type: GatheringProjectile
 
 - type: entity
@@ -574,8 +573,8 @@
         - MobState
     damage:
       types:
-        Blunt: 1
-        Slash: 5
+        Blunt: 2
+        Slash: 10 #mira change
 
 - type: entity
   parent: BaseBullet

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Projectiles/projectiles.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Projectiles/projectiles.yml
@@ -478,6 +478,7 @@
   id: BulletKinetic
   name: kinetic bolt
   parent: BaseBullet
+  categories: [ HideSpawnMenu ]
   description: Not too bad, but you still don't want to get hit by it.
   components:
   - type: Reflective
@@ -496,8 +497,8 @@
         Blunt: 20
         Structural: 30
   # Short lifespan
-#  - type: TimedDespawn
-#    lifetime: 0.22 # roughly 5.5 tiles
+  - type: TimedDespawn
+    lifetime: 0.22 # roughly 5.5 tiles
   - type: GatheringProjectile
 
 - type: entity

--- a/Resources/Prototypes/Entities/Objects/Weapons/Melee/mining.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Melee/mining.yml
@@ -137,8 +137,7 @@
         Brute: -6
   - type: Gun
     soundGunshot: /Audio/Weapons/plasma_cutter.ogg
-    fireRate: 1
-    useKey: false
+    fireRate: 1 #removed usekey
   - type: RechargeBasicEntityAmmo
     rechargeCooldown: 0.5
     rechargeSound:
@@ -149,6 +148,7 @@
     count: 1
   - type: MeleeWeapon
     attackRate: 1
+    angle: 0  #mira change
     wideAnimationRotation: -135
     damage:
       types:
@@ -156,6 +156,8 @@
         Slash: 6 #mira change
     soundHit:
       collection: MetalThud
+  - type: AltFireMelee  #mira change
+    attackType: Heavy
   - type: Wieldable
   - type: IncreaseDamageOnWield
     damage:
@@ -166,6 +168,13 @@
   - type: GunRequiresWield
   - type: DisarmMalus
   - type: Prying
+  - type: UpgradeableGun  #mira change
+    whitelist:
+      tags:
+      - PKAUpgrade
+  - type: ContainerContainer
+    containers:
+      upgrades: !type:Container
 
 # No mark ability in exchange for wideswing, autoattack, and being one-handed
 - type: entity
@@ -216,8 +225,6 @@
     slots:
     - Back
     - suitStorage
-  - type: UseDelay
-    delay: 0.9 #mira change
   - type: BasicEntityAmmoProvider
     proto: BulletChargeGlaive
     capacity: 1
@@ -236,6 +243,7 @@
       - Pickaxe
   - type: MeleeWeapon
     attackRate: 1
+    angle: 0  #mira change
     wideAnimationRotation: -135
     damage:
       types:
@@ -247,3 +255,10 @@
         Blunt: 2
         Slash: 6
         Structural: 20
+  - type: UpgradeableGun #mira change
+    whitelist:
+      tags:
+      - PKAUpgrade
+  - type: ContainerContainer
+    containers:
+      upgrades: !type:Container

--- a/Resources/Prototypes/Entities/Objects/Weapons/Melee/mining.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Melee/mining.yml
@@ -132,10 +132,9 @@
     delay: 0.9
   - type: LeechOnMarker
     userEffects:
-    - !type:HealthChange
+    - !type:EvenHealthChange #mira change
       damage:
-        groups:
-          Brute: -6
+        Brute: -6
   - type: Gun
     soundGunshot: /Audio/Weapons/plasma_cutter.ogg
     fireRate: 1
@@ -154,7 +153,7 @@
     damage:
       types:
         Blunt: 6
-        Slash: 4
+        Slash: 6 #mira change
     soundHit:
       collection: MetalThud
   - type: Wieldable
@@ -218,17 +217,20 @@
     - Back
     - suitStorage
   - type: UseDelay
-    delay: 1.9
+    delay: 0.9 #mira change
   - type: BasicEntityAmmoProvider
     proto: BulletChargeGlaive
     capacity: 1
     count: 1
   - type: LeechOnMarker
     userEffects:
-      - !type:HealthChange
+      - !type:EvenHealthChange #mira change
         damage:
-          groups:
-            Brute: -21
+          Brute: -15
+          Airloss: -2
+      - !type:MovespeedModifier
+        walkSpeedModifier: 1.2
+        sprintSpeedModifier: 1.2
   - type: Tag
     tags:
       - Pickaxe


### PR DESCRIPTION
## About the PR
Partially reverts the salvage nerf, although not entirely.
Weapons are weaker than they were before the nerf, but stronger than they are now.
Mobs are similarly a bit stronger, but not quite returning to their peaks.
also fixes bug where Basilisks and Hive Lords were invincible.

Crushers and Crusher Glaives are now guns first, their fire their projectile with primary and have wide-swing melee spear attacks on secondary. They're also now effected by PKA modkits because why not (only effects projectile).

Salvage modsuits now have magboots by default. Basic and Expanded modsuit storages can also hold up to Huge-sized items, the same as regular backpacks. Previously, you couldn't stick a PKA in modsuit storage which was annoying.

## Why / Balance
Having salvage weapons only be effective against salvage mobs is kinda dumb. Let the lads have decent weapons, they're nothing compared to security anyhow.

## Technical details
Purely YAML

## Media

## Requirements
<!-- Confirm the following by placing an X in the brackets [X]: -->
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.

## Breaking changes
added hashtag mira change to any changed yamls.

**Changelog**
- tweak: Salvagers start with a mineral scanner
- tweak: Salvage weapons and salvage enemies are stronger.
- tweak: Salvage Crusher weapons now shoot with primary fire and act as spears with secondary fire.
- tweak: Salvage Modsuits now come with magboots.
